### PR TITLE
[elao.app] Introduce integration warn option

### DIFF
--- a/elao.app/.manala/jenkins/Jenkinsfile.tmpl
+++ b/elao.app/.manala/jenkins/Jenkinsfile.tmpl
@@ -118,9 +118,17 @@ stage('{{- include "node_label" $node -}}') {
 {{- define "node_shell" -}}
     {{- $node := . -}}
 stage('{{- include "node_label" $node -}}') {
+    {{- if get $node "warn" }}
+    warnError('{{- include "node_label" $node -}}') {
+        sh '''
+            {{ $node.shell }}
+        '''
+    }
+    {{- else }}
     sh '''
         {{ $node.shell }}
     '''
+    {{- end }}
 }
 {{- end -}}
 

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -123,6 +123,7 @@ integration:
               - shell: make install@integration
               - shell: make lint@integration
               - shell: make test@integration
+                warn: true # Errors will be treated as warnings
                 env:
                     DATABASE_URL: mysql://root@127.0.0.1:3306/app
           - app: mobile
@@ -130,6 +131,7 @@ integration:
               - shell: make install@integration  
               - shell: make lint@integration
               - shell: make test@integration
+                warn: true
 ```
 
 Add in your `Makefile`:


### PR DESCRIPTION
This allows integration tasks to continue even if a stage fail. Integration will be in "unstable" state instead of "failed".

Fix https://github.com/manala/manala-recipes/issues/5