### PR TITLE
[Elao - App] Recusrsively apply integration warns

### DIFF
--- a/elao.app/.manala/jenkins/Jenkinsfile.tmpl
+++ b/elao.app/.manala/jenkins/Jenkinsfile.tmpl
@@ -10,7 +10,7 @@
 {{- end -}}
 
 {{- define "node" -}}
-    {{- $node := . -}}
+    {{- $node := mergeOverwrite (dict "warn" false) . -}}
     {{- $indent := 0 -}}
     {{- $indent_env := 0 -}}
     {{- $indent_dir := 0 -}}
@@ -104,13 +104,13 @@ stage('{{- include "node_label" $node -}}') {
     parallel(
         {{- range $i, $task := $node.tasks }}{{ if $i }},{{ end }}
         '{{- include "node_label" $task -}}': {
-            {{- include "node" $task | trim | nindent 12 }}
+            {{- include "node" (mergeOverwrite (dict "warn" $node.warn) $task) | trim | nindent 12 }}
         }{{ end }}
     )
 }
 {{- else -}}
     {{- range $i, $task := $node.tasks }}
-        {{- include "node" $task -}}
+        {{- include "node" (mergeOverwrite (dict "warn" $node.warn) $task) -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -116,6 +116,7 @@ integration:
       - label: Integration # Optionnal
         parallel: true # ! Careful ! Could *NOT* be nested !
         junit: report/junit/*.xml # Optionnal
+        warn: true # Turn errors into warnings (recursively applied)
         tasks:
           - app: api # Optionnal
             tasks:
@@ -124,7 +125,6 @@ integration:
               - shell: make lint.php-cs-fixer@integration
               - shell: make security.symfony@integration
               - shell: make test.phpunit@integration
-                warn: true # Turn errors into warnings
                 env:
                     DATABASE_URL: mysql://root@127.0.0.1:3306/app
           - app: mobile
@@ -133,7 +133,6 @@ integration:
               - shell: make build@integration
               - shell: make lint.eslint@integration
               - shell: make test.jest@integration
-                warn: true
 ```
 
 Add in your `Makefile`:


### PR DESCRIPTION
Before:
```
      - label: Integration
        junit: report/junit/*.xml
        parallel: true
        tasks:
          - label: Lint
            tasks:
              - shell: make lint.php-cs-fixer@integration
                warn: true
              - shell: make lint.twig@integration
                warn: true
              - shell: make lint.yaml@integration
                warn: true
          - label: Security
            tasks:
              - shell: make security.symfony@integration
                warn: true
              - shell: make security.yarn@integration
                warn: true
          - label: Test
            tasks:
              - shell: make test.phpunit@integration
                warn: true
                env:
                    DATABASE_URL: mysql://root@127.0.0.1:3306/app
                    APP_ELASTIC_SEARCH_HOST: 127.0.0.1
                    APP_ELASTIC_SEARCH_PORT: 9200
```
After:
```
      - label: Integration
        junit: report/junit/*.xml
        parallel: true
        warn: true
        tasks:
          - label: Lint
            tasks:
              - shell: make lint.php-cs-fixer@integration
              - shell: make lint.twig@integration
              - shell: make lint.yaml@integration
          - label: Security
            tasks:
              - shell: make security.symfony@integration
              - shell: make security.yarn@integration
          - label: Test
            tasks:
              - shell: make test.phpunit@integration
                env:
                    DATABASE_URL: mysql://root@127.0.0.1:3306/app
                    APP_ELASTIC_SEARCH_HOST: 127.0.0.1
                    APP_ELASTIC_SEARCH_PORT: 9200
```