### PR TITLE
[Elao - App] Supports MariaDB 10.4

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -29,11 +29,11 @@ system:
     nodejs:
         # @schema {"enum": [null, 12, 10, 8, 6]}
         version: ~
+    mariadb:
+        # @schema {"enum": [null, 10.4, 10.3, 10.2, 10.1, "10.0"]}
+        version: ~
     mysql:
         # @schema {"enum": [null, 5.7, 5.6]}
-        version: ~
-    mariadb:
-        # @schema {"enum": [null, 10.3, 10.2, 10.1, "10.0"]}
         version: ~
     elasticsearch:
         # @schema {"enum": [null, 7, 6, 5, 2, 1.7, 1.6, 1.5]}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -83,12 +83,12 @@ system:
         version: "*"
     nodejs:
         version: 12
-    # MySQL...
+    # MariaDB
+    mariadb:
+        version: 10.4
+    # ...*OR* MySQL...
     mysql:
         version: 5.7
-    # ...*OR* MariaDB
-    mariadb:
-        version: 10.3
     elasticsearch:
         version: 7
         plugins:


### PR DESCRIPTION
Note that mariadb is now promoted as the first mysqlalternative choice