### PR TITLE
[Elao - App] Allow multiple jenkins artifacts

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -72,7 +72,7 @@ system:
 #                     "propertyNames": {"pattern": "^[A-Z_]+$"}
 #                 },
 #                 "junit": {"type": "string"},
-#                 "artifacts": {"type": "string"},
+#                 "artifacts": {"type": ["string", "array"]},
 #                 "shell": {"type": "string"},
 #                 "warn": {"type": "boolean"},
 #                 "tasks": {"type": "array", "items": {"$ref": "#integration"}}

--- a/elao.app/.manala/jenkins/Jenkinsfile.tmpl
+++ b/elao.app/.manala/jenkins/Jenkinsfile.tmpl
@@ -130,7 +130,13 @@ try {
     junit allowEmptyResults: true, testResults: '{{ $node.junit }}'
     {{- end }}
     {{- if not (empty $node.artifacts) }}
-    archiveArtifacts allowEmptyArchive: true, artifacts: '{{ $node.artifacts }}'
+    archiveArtifacts allowEmptyArchive: true, artifacts: '
+      {{- if kindIs "slice" $node.artifacts -}}
+        {{ $node.artifacts | join "," }}
+      {{- else -}}
+        {{ $node.artifacts }}
+      {{- end -}}
+    '
     {{- end }}
 }
 {{- end -}}


### PR DESCRIPTION
Both syntax availables, string or array.

```
integration
  tasks:
    ...
    # Only one artifact :(
    - shell: foo
      artifacts: var/logs/*.log

    # Mulitpe artifacts \o/
    - shell: bar
      artifacts:
        - var/logs/*.log
        - var/sync_reports/*.html
```