### PR TITLE
[Elao - App] Allow deploy ref specification

### DIFF
--- a/elao.app/.manala/ansible/deploy.inventory.yaml.tmpl
+++ b/elao.app/.manala/ansible/deploy.inventory.yaml.tmpl
@@ -26,7 +26,7 @@ all:
                 deploy_strategy: git
                 deploy_strategy_git_repo: {{ .repo }}
                 {{- if hasKey $release "mode" }}
-                deploy_strategy_git_version: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
+                deploy_strategy_git_ref: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
                 {{- end }}
                 deploy_dir: {{ $release.deploy_dir }}
                 {{- if hasKey $release "deploy_tasks" }}

--- a/elao.app/.manala/ansible/roles/deploy/defaults/main.yml
+++ b/elao.app/.manala/ansible/roles/deploy/defaults/main.yml
@@ -14,7 +14,7 @@ deploy_strategy: git
 
 # Strategy - Git
 deploy_strategy_git_repo:    ~
-deploy_strategy_git_version: master
+deploy_strategy_git_ref: master
 
 # [READ-ONLY] This variable will be filled with the head commit hash
 deploy_strategy_git_head: ~

--- a/elao.app/.manala/ansible/roles/deploy/tasks/strategy/git.yml
+++ b/elao.app/.manala/ansible/roles/deploy/tasks/strategy/git.yml
@@ -7,7 +7,7 @@
       git:
         repo:           "{{ deploy_strategy_git_repo }}"
         dest:           "{{ deploy_dir ~ '/repo' }}"
-        version:        "{{ deploy_strategy_git_version }}"
+        version:        "{{ deploy_strategy_git_ref }}"
         accept_hostkey: true
         update:         true
 

--- a/elao.app/.manala/make/Makefile.tmpl
+++ b/elao.app/.manala/make/Makefile.tmpl
@@ -37,12 +37,13 @@ release{{ include "release_target" $release }}:
 			--limit {{ include "release_group" $release }}
 
 {{ if hasKey $release "deploy_hosts" -}}
-HELP += $(call help,deploy{{ include "release_target" $release }},Deploy {{ include "release_help" $release }})
+HELP += $(call help,deploy{{ include "release_target" $release }},Deploy {{ include "release_help" $release }} (REF))
 deploy{{ include "release_target" $release }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
 deploy{{ include "release_target" $release }}:
 	ansible-playbook .manala/ansible/deploy.yaml \
 		--inventory .manala/ansible/deploy.inventory.yaml \
-		--limit {{ include "release_group" $release }}
+		--limit {{ include "release_group" $release }} \
+		$(if $(REF),--extra-vars '{"deploy_strategy_git_ref": "$(REF)"}')
 
 {{ end -}}
 


### PR DESCRIPTION
Before:
```
$ make deploy@production
```

After:
```
$ make deploy@production
or/and
$ make deploy@production REF=v1.2.3
```

\o/