### PR TITLE
[Lazy - Symfony] Docker ports range

### DIFF
--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -30,6 +30,8 @@ app: ~
 ##########
 
 system:
+    # @schema {"enum": [8000, 9000, 10000]}
+    ports: 8000
     nginx:
         # @option {"label": "Nginx version"}
         # @schema {"enum": [1.18]}

--- a/lazy.symfony/.manala/docker-compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker-compose.yaml.tmpl
@@ -20,7 +20,7 @@ services:
       target: nginx
     restart: always
     ports:
-      - '8080:80'
+      - '{{ add .Vars.system.ports 80 }}:80'
     volumes:
       - ./nginx/app.conf:/etc/nginx/conf.d/default.conf:ro
       - ..:/srv:cached
@@ -40,7 +40,7 @@ services:
       target: mariadb
     restart: always
     ports:
-      - '8306:3306'
+      - '{{ add .Vars.system.ports 306 }}:3306'
     volumes:
       - mariadb:/var/lib/mysql:delegated
       - ./mariadb:/docker-entrypoint-initdb.d:ro
@@ -56,7 +56,7 @@ services:
       target: phpmyadmin
     restart: always
     ports:
-      - '8300:80'
+      - '{{ add .Vars.system.ports 300 }}:80'
     links:
       - mariadb
 
@@ -73,7 +73,7 @@ services:
       target: maildev
     restart: always
     ports:
-      - '8025:80'
+      - '{{ add .Vars.system.ports 25 }}:80'
 
   #######
   # App #


### PR DESCRIPTION
Docker ports range can now be specified on a per project basis.

Default ports range (8080, 8306, 8300, 8025).
```
system:
    ports: 8000
```

Punks-à-chiens ports range (9080, 9306, 9300, 9025)
```
system:
    ports: 9000
```

...