### PR TITLE
[Elao - App] System version incompatible types

### DIFF
--- a/elao.app/.manala/Dockerfile.tmpl
+++ b/elao.app/.manala/Dockerfile.tmpl
@@ -13,7 +13,7 @@ LABEL maintainer="Elao <contact@elao.com>"
 # It's also internally used for checking we're running inside a container too.
 ENV \
   container="docker" \
-  {{- if eq .version 8 }}
+  {{- if eq (.version|int) 8 }}
   ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python"
   {{- else }}
   ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python3"
@@ -42,18 +42,18 @@ RUN \
     && echo "docker ALL=(ALL) NOPASSWD:ALL" \
         > /etc/sudoers.d/docker \
     # Ansible
-    {{- if eq .version 8 }}
+    {{- if eq (.version|int) 8 }}
     && echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" \
-    {{- else if eq .version 9 }}
+    {{- else if eq (.version|int) 9 }}
     && echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
-    {{- else if eq .version 10 }}
+    {{- else if eq (.version|int) 10 }}
     && echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" \
     {{- end }}
         > /etc/apt/sources.list.d/ppa_launchpad_net_ansible_ansible_ubuntu.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 \
     && apt-get update \
     && apt-get install --yes --no-install-recommends \
-    {{- if eq .version 8 }}
+    {{- if eq (.version|int) 8 }}
         ansible python python-apt
     {{- else }}
         ansible python3 python3-apt

--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -17,7 +17,7 @@ printf "[\033[36mEnvironment\033[0m] \033[32mSetup...\033[0m\n"
 # - set `container` environment variable for environment checks
 cat <<EOF > /etc/environment
 container="vagrant"
-{{- if eq .version 8 }}
+{{- if eq (.version|int) 8 }}
 ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python"
 {{- else }}
 ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python3"
@@ -49,7 +49,7 @@ printf "[\033[36mMotd\033[0m] \033[32mClean...\033[0m\n"
 
 rm -Rf /etc/motd
 
-{{- if eq .version 8 }}
+{{- if eq (.version|int) 8 }}
 
 ##########
 # Manala #
@@ -81,7 +81,7 @@ apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --purge --auto-remove dist-upgrade
 printf "[\033[36mSystem\033[0m] \033[32mInstall...\033[0m\n"
 
 apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
-{{- if eq .version 9 }}
+{{- if eq (.version|int) 9 }}
   dirmngr \
 {{- end }}
   linux-headers-amd64
@@ -93,11 +93,11 @@ apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versi
 printf "[\033[36mAnsible\033[0m] \033[32mSetup...\033[0m\n"
 
 cat <<EOF > /etc/apt/sources.list.d/ppa_launchpad_net_ansible_ansible_ubuntu.list
-{{- if eq .version 8 }}
+{{- if eq (.version|int) 8 }}
 deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main
-{{- else if eq .version 9 }}
+{{- else if eq (.version|int) 9 }}
 deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main
-{{- else if eq .version 10 }}
+{{- else if eq (.version|int) 10 }}
 deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main
 {{- end }}
 EOF
@@ -105,7 +105,7 @@ EOF
 apt-key adv --quiet --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 93C4A3FD7BB9C367
 apt-get --quiet update
 apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
-{{- if eq .version 8 }}
+{{- if eq (.version|int) 8 }}
   ansible python python-apt python-docker python-mysqldb
 {{- else }}
   ansible python3 python3-apt python3-docker python3-mysqldb


### PR DESCRIPTION
Numeric variables coming from terminal user interface (aka. drop down during "init" command) and yaml parsing (during "update" command) are not the same types.
First ones are "float64" as a result of json schema parsing, other ones ar "int".

A simple comparison in templates such as `{{ if eq .version 8 }}` leads to an error message during project init (`error calling eq: incompatible types for comparison`) because an "int" could not be compared to a "float64".

Such variables *MUST* be converted, with something like `{{ if eq (.version|int) 8 }}`