### PR TITLE
[Elao - App] Fix ansible python interpreter

### DIFF
--- a/elao.app/.manala/Dockerfile.tmpl
+++ b/elao.app/.manala/Dockerfile.tmpl
@@ -12,12 +12,7 @@ LABEL maintainer="Elao <contact@elao.com>"
 # Docker container environment.
 # It's also internally used for checking we're running inside a container too.
 ENV \
-  container="docker" \
-  {{- if eq (.version|int) 8 }}
-  ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python"
-  {{- else }}
-  ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python3"
-  {{- end }}
+  container="docker"
 
 RUN \
     # Disable irrelevants apt-key warnings

--- a/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
@@ -15,6 +15,7 @@ deploy:
                     {{- if hasKey $host "ssh_args" }}
                     ansible_ssh_extra_args: {{ $host.ssh_args }}
                     {{- end }}
+                    ansible_python_interpreter: auto_silent
                     {{- $host = omit $host "ssh_host" "ssh_user" "ssh_args" -}}
                     {{- if $host }}
                     # Host

--- a/elao.app/.manala/ansible/inventories/release.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/release.yaml.tmpl
@@ -6,6 +6,11 @@ release:
             hosts:
                 localhost{{ include "release_host" $release }}:
                     ansible_connection: local
+                    {{- if eq ($.Vars.system.version|int) 8 }}
+                    ansible_python_interpreter: /usr/bin/python
+                    {{- else }}
+                    ansible_python_interpreter: /usr/bin/python3
+                    {{- end }}
             vars:
                 release_dir: /srv/release/{{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
                 release_git_dir: /srv/app

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -10,6 +10,11 @@ system:
         development:
             # Ansible
             ansible_connection: local
+            {{- if eq (.version|int) 8 }}
+            ansible_python_interpreter: /usr/bin/python
+            {{- else }}
+            ansible_python_interpreter: /usr/bin/python3
+            {{- end }}
             # Accounts
             manala_accounts_enabled: true
             # Motd
@@ -84,6 +89,11 @@ system:
         integration:
             # Ansible
             ansible_connection: local
+            {{- if eq (.version|int) 8 }}
+            ansible_python_interpreter: /usr/bin/python
+            {{- else }}
+            ansible_python_interpreter: /usr/bin/python3
+            {{- end }}
             # Apt
             manala_apt_enabled: true
             manala_apt_packages:

--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -17,11 +17,6 @@ printf "[\033[36mEnvironment\033[0m] \033[32mSetup...\033[0m\n"
 # - set `container` environment variable for environment checks
 cat <<EOF > /etc/environment
 container="vagrant"
-{{- if eq (.version|int) 8 }}
-ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python"
-{{- else }}
-ANSIBLE_PYTHON_INTERPRETER="/usr/bin/python3"
-{{- end }}
 EOF
 
 #########


### PR DESCRIPTION
Using `ANSIBLE_PYTHON_INTERPRETER` environment variables was not a good idea, given that some distant hosts could be on distributions unable to support python 3 or python 3 decent version (aka. jessie).
If environment/integration hosts let ansible python interpreter set to python 3 because they can support it, deployment become impossible on  retarded distributions, because `ANSIBLE_PYTHON_INTERPRETER` environment variables is applied on every fucking host.

A new approach is to define python interpreter in inventory variables, in a fixed version where it can be guessed, or on an `auto_silent` one for others (such as deployment hosts)

See: https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html

💋 