### PR TITLE
[Elao - App] Fix MariaDB 10.5 dev config

### DIFF
--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -398,6 +398,9 @@ system:
         {{- if .mysql.version }}
         manala_mysql_configs_dir: /etc/mysql/mysql.conf.d
         {{- end }}
+        {{- if gt (.mariadb.version|float64) 10.4 }}
+        manala_mysql_configs_dir: /etc/mysql/mariadb.conf.d
+        {{- end }}
         manala_mysql_configs:
           - file: zz-mysqld.cnf
             template: configs/default.dev.j2


### PR DESCRIPTION
In MariaDB 10.5 `/etc/mysql/mariadb.conf.d` overrides `/etc/mysql/conf.d` ; we change configs directory accordingly.