### PR TITLE
[Elao - App] Basic MongoDB support

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -115,6 +115,10 @@ system:
         privileges: []
         # @schema {"items": {"type": "object"}}
         config: []
+    mongodb:
+        # @option {"label": "MongoDB version"}
+        # @schema {"enum": [null, 4.4, 4.2]}
+        version: ~
     ssh:
         client:
             # @schema {"items": {"type": "object"}}

--- a/elao.app/.manala.yaml.tmpl.dist
+++ b/elao.app/.manala.yaml.tmpl.dist
@@ -98,6 +98,11 @@ system:
         config: []
     {{- end }}
 
+    {{- if .mongodb.version }}
+    mongodb:
+        version: {{ .mongodb.version | toYaml }}
+    {{- end }}
+
     # files:
     #   # Single symfony app
     #   # ------------------

--- a/elao.app/.manala/Vagrantfile.tmpl
+++ b/elao.app/.manala/Vagrantfile.tmpl
@@ -73,7 +73,7 @@ Vagrant.configure('2') do |config|
       puts "\e[32m`.\e[0m \e[33m__/ \\__\e[0m \e[32m.'\e[0m{{ if or .Vars.system.mysql.version .Vars.system.mariadb.version }}  PhpMyAdmin: http://{{ .Vars.system.hostname }}:1979{{ end }}"
       puts "\e[31m_ _\e[0m\e[33m\\     /\e[0m\e[31m_ _\e[0m{{ if .Vars.system.supervisor.configs }}  Supervisor: http://{{ .Vars.system.hostname }}:9001{{ end }}"
       puts "   \e[33m/_   _\\\e[0m{{ if .Vars.system.redis.version }}     PhpRedisAdmin: http://{{ .Vars.system.hostname }}:1981{{ end }}"
-      puts " \e[32m.'\e[0m  \e[33m\\ /\e[0m  \e[32m`.\e[0m"
+      puts " \e[32m.'\e[0m  \e[33m\\ /\e[0m  \e[32m`.\e[0m{{ if .Vars.system.mongodb.version }}   Mongo Express: http://{{ .Vars.system.hostname }}:1982{{ end }}"
       puts "   \e[31m/\e[0m  \e[32m:\e[0m  \e[31m\\\e[0m"
       puts "      \e[32m'\e[0m"
     end

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -79,6 +79,8 @@ system:
             manala_elasticsearch_enabled: {{ not (empty .elasticsearch.version) | ternary "true" "false" }}
             # InfluxDB
             manala_influxdb_enabled: {{ not (empty .influxdb.version) | ternary "true" "false" }}
+            # MongoDB
+            manala_mongodb_enabled: {{ not (empty .mongodb.version) | ternary "true" "false" }}
             # Docker
             manala_docker_enabled: true
             # Gomplate
@@ -225,6 +227,8 @@ system:
             state: {{ `"{{ (manala_elasticsearch_enabled) | ternary('present', 'absent') }}"` }}
           - preference: influxdb@{{ not (empty .influxdb.version) | ternary "influxdata" "default" }}
             state: {{ `"{{ (manala_influxdb_enabled) | ternary('present', 'absent') }}"` }}
+          - preference: mongodb@{{ not (empty .mongodb.version) | ternary (print "mongodb_" .mongodb.version | replace "." "_") "default" }}
+            state: {{ `"{{ (manala_mongodb_enabled) | ternary('present', 'absent') }}"` }}
         {{- if .apt.preferences }}
           # App
           {{- .apt.preferences | toYaml | nindent 10 }}
@@ -462,6 +466,11 @@ system:
         {{- end }}
         {{- end }}
 
+        {{- if .mongodb.version }}
+        # MongoDB
+        manala_mongodb_config_template: mongodb/mongod.conf.j2
+        {{- end }}
+
         # Docker
         manala_docker_containers:
           - name: mailhog
@@ -491,6 +500,15 @@ system:
               REDIS_1_HOST: 172.17.0.1
             ports:
               - 1981:80
+          - name: mongo-express
+            image: mongo-express
+            state: {{ not (empty .mongodb.version) | ternary "started" "absent" }}
+            restart_policy: unless-stopped
+            env:
+              # Default docker host ip
+              ME_CONFIG_MONGODB_SERVER: 172.17.0.1
+            ports:
+              - 1982:8081
         {{- if .docker.containers }}
           # App
           {{- .docker.containers | toYaml | nindent 10 }}

--- a/elao.app/.manala/ansible/roles/system/defaults/main.yaml
+++ b/elao.app/.manala/ansible/roles/system/defaults/main.yaml
@@ -28,5 +28,6 @@ manala_mysql_enabled: false
 manala_redis_enabled: false
 manala_elasticsearch_enabled: false
 manala_influxdb_enabled: false
+manala_mongodb_enabled: false
 manala_docker_enabled: false
 manala_gomplate_enabled: false

--- a/elao.app/.manala/ansible/roles/system/tasks/main.yaml
+++ b/elao.app/.manala/ansible/roles/system/tasks/main.yaml
@@ -168,6 +168,12 @@
   when: manala_influxdb_enabled
   tags: [influxdb]
 
+# MongoDB
+- import_role:
+      name: mongodb
+  when: manala_mongodb_enabled
+  tags: [mongodb]
+
 # Docker
 - import_role:
       name: docker

--- a/elao.app/.manala/ansible/templates/mongodb/mongod.conf.j2
+++ b/elao.app/.manala/ansible/templates/mongodb/mongod.conf.j2
@@ -1,0 +1,43 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongodb
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: 0.0.0.0
+
+
+# how the process runs
+processManagement:
+  timeZoneInfo: /usr/share/zoneinfo
+
+#security:
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options:
+
+#auditLog:
+
+#snmp:

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -183,6 +183,8 @@ system:
     #         grant: ALL
     #     config:
     #       - reporting-disabled: true
+    # mongodb:
+    #     version: 4.4
     ssh:
         config: |
             Host *.elao.run


### PR DESCRIPTION
Only versions 4.2/4.4, and no integration :)

Usage:
```
system:
    ...
    mongodb:
        version: 4.4
```

And zou !

(don't forget to enable the relating php extension ;) )

```
system:
    ...
    php:
        extensions:
            ...
            - mongodb
```

🌴 ([mongo-express](https://github.com/mongo-express/mongo-express) is also activated as a docker image)