### PR TITLE
[Elao - App] Generate docker-compose.yaml for Github Actions

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -3,6 +3,7 @@ manala:
     sync:
       - .manala/ansible
       - .manala/docker
+      - .manala/github
       - .manala/jenkins
       - .manala/make
       - .manala/vagrant

--- a/elao.app/.manala/github/docker-compose.yaml.tmpl
+++ b/elao.app/.manala/github/docker-compose.yaml.tmpl
@@ -1,0 +1,69 @@
+version: '3.8'
+services:
+
+  registry:
+    image: 'registry:2'
+    restart: always
+    ports:
+      - 5000:5000
+    volumes:
+      - type: bind
+        source: ${RUNNER_TEMP}/docker-registry
+        target: /var/lib/registry
+
+  manala_ci:
+    image: manala_ci
+    network_mode: 'host'
+    command: 'tail -f /dev/null'
+    environment:
+      XDG_CACHE_HOME: '/docker/.cache/docker'
+      SSH_AUTH_SOCK: ${SSH_AUTH_SOCK:-/ssh-agent}
+    volumes:
+      - type: bind
+        consistency: cached
+        source: ${GITHUB_WORKSPACE}
+        target: /srv/app
+      - type: bind
+        consistency: delegated
+        source: ${GITHUB_WORKSPACE}/.manala
+        target: /docker
+      - type: bind
+        source: ${SSH_AUTH_SOCK:-/home/runner/ssh-agent}
+        target: ${SSH_AUTH_SOCK:-/ssh-agent}
+
+{{- if .Vars.system.mysql.version -}}
+{{- $mysql := .Vars.system.mysql }}
+
+  mysql:
+    image: 'mysql:{{ $mysql.version }}'
+    network_mode: 'host'
+    command: '--port=3306'
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+{{- else if .Vars.system.mariadb.version -}}
+{{- $mariadb := .Vars.system.mariadb }}
+
+  mariadb:
+    image: 'mariadb:{{ $mariadb.version }}'
+    network_mode: 'host'
+    command: '--port=3306'
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+{{- end }}
+
+{{- if .Vars.system.elasticsearch.version -}}
+{{- $elasticsearch := mergeOverwrite (dict "plugins" list) .Vars.system.elasticsearch }}
+
+  elasticsearch:
+    image: 'docker.elastic.co/elasticsearch/elasticsearch:{{ include "elasticsearch_version" $elasticsearch }}'
+    network_mode: 'host'
+    environment:
+      'discovery.type': 'single-node'
+    command: 'sh -c "
+        {{- range $plugin := $elasticsearch.plugins }}elasticsearch-plugin install --batch --verbose {{ $plugin }} && {{ end -}}
+        exec docker-entrypoint.sh"'
+{{- end }}


### PR DESCRIPTION
This docker-compose file aims to be used in a Manala CI Github Action to start services & the local registry used for caching purposes (as currently done in one of our projects).
But we can discuss later about providing one for other purposes as well (dev, utils, ...).