### PR TITLE
[Elao - App] Support supervisor groups

### DIFF
--- a/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
+++ b/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
@@ -1,14 +1,15 @@
-{%- set programs = item.programs|default({}) -%}
 {%- set groups = item.groups|default({}) -%}
 
 {% for group, parameters in groups|dictsort %}
 [group:{{ group }}]
 {{- {
-  'programs': (parameters.programs|mandatory)|join(', '),
-  'priority': parameters.priority|default(999, true),
+  'programs': parameters.programs|mandatory,
 } | combine(parameters) | manala.roles.supervisor_config_parameters }}
 
 {% endfor %}
+
+{%- set programs = item.programs|default({}) -%}
+
 {% for program, parameters in programs|dictsort %}
 [program:{{ program }}]
 {{- {

--- a/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
+++ b/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
@@ -1,5 +1,14 @@
 {%- set programs = item.programs|default({}) -%}
+{%- set groups = item.groups|default({}) -%}
 
+{% for group, parameters in groups|dictsort %}
+[group:{{ group }}]
+{{- {
+  'programs': (parameters.programs|mandatory)|join(', '),
+  'priority': parameters.priority|default(999, true),
+} | combine(parameters) | manala.roles.supervisor_config_parameters }}
+
+{% endfor %}
 {% for program, parameters in programs|dictsort %}
 [program:{{ program }}]
 {{- {

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -150,11 +150,20 @@ system:
     # supervisor:
     #     configs:
     #         - file: app.conf
+    #           groups:
+    #               acme:
+    #                   programs:
+    #                       - foo
+    #                       - bar
     #           programs:
-    #               foo-bar:
-    #                   command: zsh -c "bin/console app:foo:bar --no-interaction -vv"
+    #               foo:
+    #                   command: zsh -c "bin/console app:acme:foo --no-interaction -vv"
     #                   directory: /srv/app
-    #                   stdout_logfile: /srv/log/supervisor.foo-bar.log
+    #                   stdout_logfile: /srv/log/supervisor.acme-foo.log
+    #               bar:
+    #                   command: zsh -c "bin/console app:acme:bar --no-interaction -vv"
+    #                   directory: /srv/app
+    #                   stdout_logfile: /srv/log/supervisor.acme-bar.log
     # MariaDB
     mariadb:
         version: 10.5
@@ -554,7 +563,7 @@ secrets@staging:
 	gomplate --input-dir=secrets/staging --output-map='{{ .in | replaceAll ".gohtml" "" }}'
 ```
 
-Put your templates in `.gohtml` files inside a `secrets/[production|staging]` directory at the root of the project.  
+Put your templates in `.gohtml` files inside a `secrets/[production|staging]` directory at the root of the project.
 Respect destination file names, extensions, and paths:
 
 ```
@@ -568,7 +577,7 @@ secrets
     └── config
         └── parameters.yaml.gohtml
 ```
-	
+
 Here are some template examples:
 
 `.env.gohtml`:

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -567,7 +567,7 @@ secrets@staging:
 	gomplate --input-dir=secrets/staging --output-map='{{ .in | replaceAll ".gohtml" "" }}'
 ```
 
-Put your templates in `.gohtml` files inside a `secrets/[production|staging]` directory at the root of the project.
+Put your templates in `.gohtml` files inside a `secrets/[production|staging]` directory at the root of the project.  
 Respect destination file names, extensions, and paths:
 
 ```

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -164,6 +164,10 @@ system:
     #                   command: zsh -c "bin/console app:acme:bar --no-interaction -vv"
     #                   directory: /srv/app
     #                   stdout_logfile: /srv/log/supervisor.acme-bar.log
+    #               foo-bar:
+    #                   command: zsh -c "bin/console app:foo:bar --no-interaction -vv"
+    #                   directory: /srv/app
+    #                   stdout_logfile: /srv/log/supervisor.foo-bar.log
     # MariaDB
     mariadb:
         version: 10.5


### PR DESCRIPTION
Support for supervisor groups: http://supervisord.org/configuration.html#group-x-section-settings

Usage example:

```yaml
    supervisor:
        configs:
            - file: servers.conf
              groups:
                whatthetune:
                    programs:
                        - private
                        - hits
              programs:
                  private:
                      command: node bin/server.js 8099 localhost http --privateServer --inspect=./influx.json
                      directory: /srv/app/server
                  hits:
                      command: node bin/server.js hits 8006 localhost http --inspect=./influx.json
                      directory: /srv/app/server
```