### PR TITLE
[Elao -App] Support supervisor raw configs

### DIFF
--- a/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
+++ b/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
@@ -1,3 +1,11 @@
+{%- set config = item.config|default('') -%}
+
+{%- if config -%}
+
+{{ config }}
+
+{%- else -%}
+
 {%- set groups = item.groups|default({}) -%}
 
 {% for group, parameters in groups|dictsort %}
@@ -24,3 +32,5 @@
 } | combine(parameters) | manala.roles.supervisor_config_parameters }}
 
 {% endfor %}
+
+{%- endif -%}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -168,6 +168,10 @@ system:
     #                   command: zsh -c "bin/console app:foo:bar --no-interaction -vv"
     #                   directory: /srv/app
     #                   stdout_logfile: /srv/log/supervisor.foo-bar.log
+    #         - file: app_foo.conf
+    #           config: |
+    #               [program:foo]
+    #               command=/bin/foo
     # MariaDB
     mariadb:
         version: 10.5


### PR DESCRIPTION
Add suport for "raw" supervisor configs.

Example:
```
supervisor:
    configs:
        - file: app_foo.conf
          config: |
              [program:foo]
              command=/bin/foo
```