### PR TITLE
[Elao - App] Enable root access

### DIFF
--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -19,6 +19,14 @@ cat <<EOF > /etc/environment
 container="vagrant"
 EOF
 
+########
+# Root #
+########
+
+printf "[\033[36mRoot\033[0m] \033[32mPassword...\033[0m\n"
+
+echo "root:root" | chpasswd
+
 #########
 # Clean #
 #########


### PR DESCRIPTION
As seen here (https://github.com/chef/bento/blob/be2ca582a3908fd2ec4648bd02523cf90f261683/packer_templates/debian/http/debian-9/preseed.cfg#L25) root account is disabled on bento debian boxes during preseed.

Having a root access is useful to debug and have an emergency shell access solution when regular vagrant user is blocked for any reasons.