### PR TITLE
[Elao - App] Composer version

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -72,6 +72,9 @@ system:
         extensions: []
         # @schema {"items": {"type": "object"}}
         configs: []
+        composer:
+          # @schema {"enum": [null, 1]}
+          version: ~
     cron:
         # @schema {"items": {"type": "object"}}
         files: []

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -334,6 +334,9 @@ system:
 
         # Composer
         manala_composer_enabled: {{ `"{{ manala_php_enabled }}"` }}
+        {{- if .php.composer.version }}
+        manala_composer_version: {{ .php.composer.version | toYaml }}
+        {{- end }}
 
         # Symfony Cli
         manala_symfony_cli_enabled: {{ `"{{ manala_php_enabled }}"` }}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -162,6 +162,8 @@ system:
           - xml
           # App
           - mysql
+        # composer:
+        #   version: 1 # Optional
     nodejs:
         version: 14
         # packages:


### PR DESCRIPTION
```
system:
    ....
    php:
        ...
        composer:
            version: 1
```

Note: only composer version **1** is supported to handle legacy projects. If you want latest stable, don't specify version.