### PR TITLE
[Elao - App] Support app sessions directory

### DIFF
--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -272,10 +272,15 @@ system:
           - path: "^/srv/cache"
             user: vagrant
             group: vagrant
+          - path: "^/srv/sessions"
+            user: vagrant
+            group: vagrant
         manala_files_attributes:
           - path: /srv/log
             state: directory
           - path: /srv/cache
+            state: directory
+          - path: /srv/sessions
             state: directory
           - path: /usr/share/nginx/html/404.html
             template: nginx/html/404.html.j2

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -128,6 +128,10 @@ system:
       - path: /srv/app/var/cache
         src: /srv/cache
         state: link_directory
+      #- path: /srv/app/var/sessions
+      #  src: /srv/sessions
+      #  state: link_directory
+      ## Api
       #- path: /srv/app/api/var/log
       #  src: /srv/log/api
       #  state: link_directory


### PR DESCRIPTION
When projects takes care of their sessions storage

```
system:
    files:
        ...
        - path: /srv/app/var/sessions
          src: /srv/sessions
          state: link_directory
```