### PR TITLE
[Elao - App] Stop pre-installing ansible related packages

### DIFF
--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -123,9 +123,9 @@ apt-key adv --quiet --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 93C4A3
 apt-get --quiet update
 apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
 {{- if eq (.version|int) 8 }}
-  ansible python python-apt python-docker python-mysqldb
+  python ansible
 {{- else }}
-  ansible python3 python3-apt python3-docker python3-mysqldb
+  python3 ansible
 {{- end }}
 
 install --directory /root/.ansible/tmp --verbose


### PR DESCRIPTION
As it leads to serious issues, just like having mariadb config alternative because `python-mysqldb` package is coming with `mariadb-common` dependency...