### PR TITLE
[Elao - App] MySQL 8.0 support

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -93,7 +93,7 @@ system:
         version: ~
     mysql:
         # @option {"label": "MySQL version"}
-        # @schema {"enum": [null, 5.7, 5.6]}
+        # @schema {"enum": [null, "8.0", 5.7, 5.6]}
         version: ~
     redis:
         # @option {"label": "Redis version"}

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -408,8 +408,7 @@ system:
         manala_mysql_configs_dir: /etc/mysql/mariadb.conf.d
         {{- end }}
         manala_mysql_configs:
-          - file: zz-mysqld.cnf
-            template: configs/default.dev.j2
+          - template: mysql/zz-mysqld.cnf.j2
         manala_mysql_users:
           # Create a password-less/any-host root user...
           - name: root

--- a/elao.app/.manala/ansible/templates/mysql/zz-mysqld.cnf.j2.tmpl
+++ b/elao.app/.manala/ansible/templates/mysql/zz-mysqld.cnf.j2.tmpl
@@ -1,0 +1,6 @@
+[mysqld]
+bind-address = 0.0.0.0
+{{- if eq (.Vars.system.mysql.version|float64) 8.0 }}
+# Use native authentication plugin
+default-authentication-plugin = mysql_native_password
+{{- end }}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -213,7 +213,7 @@ system:
         version: 10.5
     # ...*OR* MySQL...
     mysql:
-        version: 5.7
+        version: "8.0"
     # redis:
     #     version: "*"
     #     config:


### PR DESCRIPTION
Note that we have to set `default-authentication-plugin` to `mysql_native_password` to ensure users provisionning don't break under ansible 2.9