### PR TITLE
[Elao - App] Specify git ref

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -167,6 +167,7 @@ integration: {}
 #                 "app": {"type": "string", "pattern": "^[a-z]+$"},
 #                 "mode": {"type": "string", "pattern": "^[a-z]+$"},
 #                 "repo": {"type": "string", "format": "git-repo"},
+#                 "ref": {"type": "string", "pattern": "^[\\w-/]+$"},
 #                 "release_tasks": {"type": "array", "items": {"$ref": "#release_task"}},
 #                 "release_add": {"type": "array", "items": {"type": "string"}},
 #                 "release_removed": {"type": "array", "items": {"type": "string"}},

--- a/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
@@ -25,8 +25,10 @@ deploy:
             vars:
                 deploy_releases: {{ if hasKey $release "deploy_releases" }}{{ $release.deploy_releases }}{{ else }}3{{ end }}
                 deploy_strategy: git
-                deploy_strategy_git_repo: {{ .repo }}
-                {{- if hasKey $release "mode" }}
+                deploy_strategy_git_repo: {{ $release.repo }}
+                {{- if hasKey $release "ref" }}
+                deploy_strategy_git_ref: {{ $release.ref }}
+                {{- else if hasKey $release "mode" }}
                 deploy_strategy_git_ref: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
                 {{- end }}
                 deploy_dir: {{ $release.deploy_dir }}

--- a/elao.app/.manala/ansible/inventories/release.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/release.yaml.tmpl
@@ -19,7 +19,9 @@ release:
                 release_target_dir: {{ $release.app }}
                 {{- end }}
                 release_repo: {{ $release.repo }}
-                {{- if hasKey $release "mode" }}
+                {{- if hasKey $release "ref" }}
+                release_version: {{ $release.ref }}
+                {{- else if hasKey $release "mode" }}
                 release_version: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
                 {{- end }}
                 {{- if hasKey $release "release_tasks" }}

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -449,6 +449,7 @@ releases:
     #app: api # Optional
     mode: production
     repo: git@git.elao.com:<vendor>/<app>-release.git
+    #ref: master # Based on app/mode by default
     # Release
     release_tasks:
       - shell: make install@production


### PR DESCRIPTION
Give a way to specify git ref (hash, branch, tag, ...) for releases.

By default, this is master, or a combination of mod/app if `mode` is specified.