### PR TITLE
[Elao - App] Deploy hosts groups

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -171,7 +171,10 @@ integration: {}
 #                 "release_tasks": {"type": "array", "items": {"$ref": "#release_task"}},
 #                 "release_add": {"type": "array", "items": {"type": "string"}},
 #                 "release_removed": {"type": "array", "items": {"type": "string"}},
-#                 "deploy_hosts": {"type": "array", "items": {"$ref": "#release_host"}},
+#                 "deploy_hosts": {"oneOf": [
+#                     {"type": "array", "items": {"$ref": "#release_host"}},
+#                     {"type": "object", "additionalProperties": {"type": "array", "items": {"$ref": "#release_host"}}}
+#                 ]},
 #                 "deploy_dir": {"type": "string", "format": "file-path"},
 #                 "deploy_releases": {"type": "integer"},
 #                 "deploy_tasks": {"type": "array", "items": {"$ref": "#release_task"}},

--- a/elao.app/.manala/Makefile.tmpl
+++ b/elao.app/.manala/Makefile.tmpl
@@ -114,6 +114,27 @@ docker:
 
 endif
 
+{{- define "release" -}}
+HELP += $(call help,release{{ include "release_target" . }},Release {{ include "release_help" . }})
+release{{ include "release_target" . }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
+release{{ include "release_target" . }}:
+	ansible-playbook $(_ROOT_DIR)/.manala/ansible/release.yaml \
+		--inventory $(_ROOT_DIR)/.manala/ansible/inventories/release.yaml \
+		--limit {{ include "release_group" . }}
+
+{{ end }}
+
+{{- define "deploy" -}}
+HELP += $(call help,deploy{{ include "release_target" . }},Deploy {{ include "release_help" . }} (REF))
+deploy{{ include "release_target" . }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
+deploy{{ include "release_target" . }}:
+	ansible-playbook $(_ROOT_DIR)/.manala/ansible/deploy.yaml \
+		--inventory $(_ROOT_DIR)/.manala/ansible/inventories/deploy.yaml \
+		--limit {{ include "release_group" . }} \
+		$(if $(REF),--extra-vars '{"deploy_strategy_git_ref": "$(REF)"}')
+
+{{ end }}
+
 {{ if .Vars.releases -}}
 ############
 # Releases #
@@ -121,32 +142,25 @@ endif
 
 HELP += $(call help_section, Releases)
 
-{{ range $release := .Vars.releases -}}
+{{ range $release := .Vars.releases }}
 
-{{ if or (hasKey $release "release_tasks") (hasKey $release "release_add") (hasKey $release "release_removed") -}}
-HELP += $(call help,release{{ include "release_target" $release }},Release {{ include "release_help" $release }})
-release{{ include "release_target" $release }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
-release{{ include "release_target" $release }}:
-	ansible-playbook $(_ROOT_DIR)/.manala/ansible/release.yaml \
-		--inventory $(_ROOT_DIR)/.manala/ansible/inventories/release.yaml \
-		--limit {{ include "release_group" $release }}
+	{{- if or (hasKey $release "release_tasks") (hasKey $release "release_add") (hasKey $release "release_removed") }}
+		{{- include "release" (dict "release" $release) }}
+	{{- end -}}
 
-{{ end -}}
+	{{- if hasKey $release "deploy_hosts" }}
+		{{- if kindIs "map" $release.deploy_hosts }}
+			{{- range $group, $hosts := $release.deploy_hosts }}
+				{{- include "deploy" (dict "release" $release "group" $group) }}
+			{{- end }}
+		{{- else -}}
+			{{- include "deploy" (dict "release" $release) }}
+		{{- end }}
+	{{- end }}
 
-{{ if hasKey $release "deploy_hosts" -}}
-HELP += $(call help,deploy{{ include "release_target" $release }},Deploy {{ include "release_help" $release }} (REF))
-deploy{{ include "release_target" $release }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
-deploy{{ include "release_target" $release }}:
-	ansible-playbook $(_ROOT_DIR)/.manala/ansible/deploy.yaml \
-		--inventory $(_ROOT_DIR)/.manala/ansible/inventories/deploy.yaml \
-		--limit {{ include "release_group" $release }} \
-		$(if $(REF),--extra-vars '{"deploy_strategy_git_ref": "$(REF)"}')
+{{- end }}
 
-{{ end -}}
-
-{{ end -}}
-
-{{ end -}}
+{{- end -}}
 
 #######
 # App #

--- a/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/deploy.yaml.tmpl
@@ -1,48 +1,69 @@
+{{- define "deploy_hosts" -}}
+{{- $deploy := . -}}
+hosts:
+{{- range $index, $host := .hosts }}
+    {{ (add $index 1) | printf "%02d" }}{{ include "release_host" $deploy }}:
+        # Ansible
+        ansible_host: {{ $host.ssh_host }}
+        {{- if hasKey $host "ssh_user" }}
+        ansible_ssh_user: {{ $host.ssh_user }}
+        {{- end }}
+        {{- if hasKey $host "ssh_args" }}
+        ansible_ssh_extra_args: {{ $host.ssh_args }}
+        {{- end }}
+        ansible_python_interpreter: auto_silent
+        {{- $host = omit $host "ssh_host" "ssh_user" "ssh_args" }}
+        {{- if $host }}
+        # Host
+        {{- $host | toYaml | nindent 8 }}
+        {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deploy_vars" -}}
+{{- $release := .release -}}
+vars:
+    deploy_releases: {{ if hasKey $release "deploy_releases" }}{{ $release.deploy_releases }}{{ else }}3{{ end }}
+    deploy_strategy: git
+    deploy_strategy_git_repo: {{ $release.repo }}
+    {{- if hasKey $release "ref" }}
+    deploy_strategy_git_ref: {{ $release.ref }}
+    {{- else if hasKey $release "mode" }}
+    deploy_strategy_git_ref: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
+    {{- end }}
+    deploy_dir: {{ $release.deploy_dir }}
+    {{- if hasKey $release "deploy_tasks" }}
+    deploy_tasks:
+        {{- include "release_tasks" $release.deploy_tasks | nindent 8 }}
+    {{- end }}
+    {{- if hasKey $release "deploy_post_tasks" }}
+    deploy_post_tasks:
+        {{- include "release_tasks" $release.deploy_post_tasks | nindent 8 }}
+    {{- end }}
+    {{- $release = pick $release "deploy_shared_files" "deploy_shared_dirs" "deploy_writable_dirs" "deploy_removed" -}}
+    {{- if $release }}
+    {{- $release | toYaml | nindent 4 }}
+    {{- end }}
+{{- end -}}
+
 deploy:
     children:
     {{- range $release := .Vars.releases }}
     {{- if hasKey $release "deploy_hosts" }}
 
-        {{ include "release_group" $release }}:
-            hosts:
-            {{- range $index, $host := $release.deploy_hosts }}
-                {{ (add $index 1) | printf "%02d" }}{{ include "release_host" $release }}:
-                    # Ansible
-                    ansible_host: {{ $host.ssh_host }}
-                    {{- if hasKey $host "ssh_user" }}
-                    ansible_ssh_user: {{ $host.ssh_user }}
-                    {{- end }}
-                    {{- if hasKey $host "ssh_args" }}
-                    ansible_ssh_extra_args: {{ $host.ssh_args }}
-                    {{- end }}
-                    ansible_python_interpreter: auto_silent
-                    {{- $host = omit $host "ssh_host" "ssh_user" "ssh_args" -}}
-                    {{- if $host }}
-                    # Host
-                    {{- $host | toYaml | nindent 20 }}
-                    {{- end }}
+        {{ include "release_group" (dict "release" $release) }}:
+
+        {{- if kindIs "map" $release.deploy_hosts }}
+            children:
+            {{- range $group, $hosts := $release.deploy_hosts }}
+                {{ include "release_group" (dict "release" $release "group" $group) }}:
+                    {{- include "deploy_hosts" (dict "release" $release "hosts" $hosts "group" $group) | nindent 20 }}
             {{- end }}
-            vars:
-                deploy_releases: {{ if hasKey $release "deploy_releases" }}{{ $release.deploy_releases }}{{ else }}3{{ end }}
-                deploy_strategy: git
-                deploy_strategy_git_repo: {{ $release.repo }}
-                {{- if hasKey $release "ref" }}
-                deploy_strategy_git_ref: {{ $release.ref }}
-                {{- else if hasKey $release "mode" }}
-                deploy_strategy_git_ref: {{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.mode }}
-                {{- end }}
-                deploy_dir: {{ $release.deploy_dir }}
-                {{- if hasKey $release "deploy_tasks" }}
-                deploy_tasks:
-                    {{- include "release_tasks" $release.deploy_tasks | nindent 18 }}
-                {{- end }}
-                {{- if hasKey $release "deploy_post_tasks" }}
-                deploy_post_tasks:
-                    {{- include "release_tasks" $release.deploy_post_tasks | nindent 18 }}
-                {{- end }}
-                {{- $release = pick $release "deploy_shared_files" "deploy_shared_dirs" "deploy_writable_dirs" "deploy_removed" -}}
-                {{- if $release }}
-                {{- $release | toYaml | nindent 16 }}
-                {{- end }}
-    {{- end -}}
+        {{- else }}
+            {{- include "deploy_hosts" (dict "release" $release "hosts" $release.deploy_hosts) | nindent 12 }}
+        {{- end }}
+
+        {{- include "deploy_vars" (dict "release" $release) | nindent 12 }}
+
+    {{- end }}
     {{- end }}

--- a/elao.app/.manala/ansible/inventories/release.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/release.yaml.tmpl
@@ -3,9 +3,9 @@ release:
     {{- range $release := .Vars.releases }}
     {{- if or (hasKey $release "release_tasks") (hasKey $release "release_add") (hasKey $release "release_removed") }}
 
-        {{ include "release_group" $release }}:
+        {{ include "release_group" (dict "release" $release) }}:
             hosts:
-                localhost{{ include "release_host" $release }}:
+                localhost{{ include "release_host" (dict "release" $release) }}:
                     ansible_connection: local
                     {{- if eq ($.Vars.system.version|int) 8 }}
                     ansible_python_interpreter: /usr/bin/python

--- a/elao.app/README.md
+++ b/elao.app/README.md
@@ -489,6 +489,12 @@ releases:
       - ssh_host: foo-01.bar.elao.local
         #master: true # Any custom variable are welcomed
       - ssh_host: foo-02.bar.elao.local
+    #deploy_hosts:
+    #  foo:
+    #    - ssh_host: foo-01.bar.elao.local
+    #      #master: true # Any custom variable are welcomed
+    #  bar:
+    #    - ssh_host: foo-02.bar.elao.local
     deploy_dir: /srv/app
     deploy_shared_files:
       - config/parameters.yml

--- a/elao.app/_helpers.tmpl
+++ b/elao.app/_helpers.tmpl
@@ -1,26 +1,32 @@
 {{/* Release makefile target */}}
 {{ define "release_target" -}}
-    {{- $release := . -}}
-    {{ if hasKey $release "app" }}.{{ $release.app }}{{ end }}@{{ $release.mode }}
-{{- end -}}
+    {{- if hasKey .release "app" }}.{{ .release.app }}{{ end -}}
+    {{- if hasKey . "group" }}/{{ .group }}{{ end -}}
+    @
+    {{- .release.mode }}
+{{- end }}
 
 {{/* Release makefile help */}}
-{{- define "release_help" -}}
-    {{- $release := . -}}
-    {{ if hasKey $release "app" }}{{ $release.app }} {{ end }}in {{ $release.mode }}
-{{- end -}}
+{{ define "release_help" -}}
+    {{- if hasKey .release "app" }}{{ .release.app }} {{ end -}}
+    {{- if hasKey . "group" }}group {{ .group }} {{ end -}}
+    in {{ .release.mode }}
+{{- end }}
 
 {{/* Release ansible group */}}
-{{- define "release_group" -}}
-    {{- $release := . -}}
-    {{ if hasKey $release "app" }}{{ $release.app }}_{{ end }}{{ $release.mode }}
-{{- end -}}
+{{ define "release_group" -}}
+    {{- if hasKey .release "app" }}{{ .release.app }}_{{ end -}}
+    {{- if hasKey . "group" }}{{ regexReplaceAll "[^[:alnum:]_]" .group "_" }}_{{ end -}}
+    {{- .release.mode }}
+{{- end }}
 
 {{/* Release ansible host */}}
-{{- define "release_host" -}}
-    {{- $release := . -}}
-    {{ if hasKey $release "app" }}.{{ $release.app }}{{ end }}@{{ $release.mode }}
-{{- end -}}
+{{ define "release_host" -}}
+    {{- if hasKey .release "app" }}.{{ .release.app }}{{ end -}}
+    {{- if hasKey . "group" }}_{{ regexReplaceAll "[^[:alnum:]_]" .group "_" }}{{ end -}}
+    @
+    {{- .release.mode }}
+{{- end }}
 
 {{/* Release ansible tasks */}}
 {{- define "release_tasks" -}}


### PR DESCRIPTION
Deploy hosts can now be **optionnaly** grouped.

Before:
```
releases:
    - mode: production
      ...
      deploy_hosts:
              - ssh_host: foo-1.com
              - ssh_host: foo-2.com
              - ssh_host: foo-2.bar.com
```

After:
```
releases:
    - mode: production
      ...
      deploy_hosts:
          foo:
              - ssh_host: foo-1.com
              - ssh_host: foo-2.com
          foo/bar:
              - ssh_host: foo-2.bar.com
```

Makefile targets are still automatically generated.