### PR TITLE
[Elao - App] Fix supervisor ansible template

### DIFF
--- a/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
+++ b/elao.app/.manala/ansible/templates/supervisor/app.conf.j2
@@ -10,9 +10,7 @@
 
 {% for group, parameters in groups|dictsort %}
 [group:{{ group }}]
-{{- {
-  'programs': parameters.programs|mandatory,
-} | combine(parameters) | manala.roles.supervisor_config_parameters }}
+{{- parameters | manala.roles.supervisor_config_section() }}
 
 {% endfor %}
 
@@ -20,16 +18,22 @@
 
 {% for program, parameters in programs|dictsort %}
 [program:{{ program }}]
-{{- {
-  'command': parameters.command|mandatory,
-  'autostart': false,
-  'startretries': 20,
-  'autorestart': true,
-  'user': 'vagrant',
-  'redirect_stderr': true,
-  'stdout_logfile_maxbytes': 0,
-  'stderr_logfile_maxbytes': 0,
-} | combine(parameters) | manala.roles.supervisor_config_parameters }}
+{{ parameters | manala.roles.supervisor_config_parameter('autorestart', default=True) }}
+{{ parameters | manala.roles.supervisor_config_parameter('autostart', default=False) }}
+{{ parameters | manala.roles.supervisor_config_parameter('redirect_stderr', default=True) }}
+{{ parameters | manala.roles.supervisor_config_parameter('startretries', default=20) }}
+{{ parameters | manala.roles.supervisor_config_parameter('stderr_logfile_maxbytes', default=0) }}
+{{ parameters | manala.roles.supervisor_config_parameter('stdout_logfile_maxbytes', default=0) }}
+{{ parameters | manala.roles.supervisor_config_parameter('user', default='vagrant') }}
+{{- parameters | manala.roles.supervisor_config_section(exclude=[
+  'autorestart',
+  'autostart',
+  'redirect_stderr',
+  'startretries',
+  'stderr_logfile_maxbytes',
+  'stdout_logfile_maxbytes',
+  'user',
+]) }}
 
 {% endfor %}
 


### PR DESCRIPTION
- [x] `manala.roles.supervisor_config_parameters` has been renamed to `manala.roles.supervisor_config_section`
- [x] Use `manala.roles.supervisor_config_parameter` when possible for a better integration