### PR TITLE
[Elao - App] Support "xz" compressed debian packages in docker

### DIFF
--- a/elao.app/.manala/Dockerfile.tmpl
+++ b/elao.app/.manala/Dockerfile.tmpl
@@ -26,6 +26,7 @@ RUN \
     && apt-get install --yes --no-install-recommends \
         bash-completion \
         gnupg dirmngr \
+        xz-utils \
         ca-certificates \
         sudo \
     # Srv


### PR DESCRIPTION
Some debian packages are compressed using "xz" format (https://snapshot.debian.org/archive/debian/20190505T225241Z/pool/main/i/imagemagick/imagemagick-6-common_6.9.10.23%2Bdfsg-2.1_all.deb).
Installing them via related ansible module "apt" need the `xz-utils` package