### PR TITLE
[Elao - App] Better xz-utils package handling

### DIFF
--- a/elao.app/.manala/Dockerfile.tmpl
+++ b/elao.app/.manala/Dockerfile.tmpl
@@ -26,7 +26,6 @@ RUN \
     && apt-get install --yes --no-install-recommends \
         bash-completion \
         gnupg dirmngr \
-        xz-utils \
         ca-certificates \
         sudo \
     # Srv

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -30,6 +30,7 @@ system:
             # Apt
             manala_apt_enabled: true
             manala_apt_packages:
+              - xz-utils
               - rsync
               - wget
               - curl
@@ -99,6 +100,7 @@ system:
             # Apt
             manala_apt_enabled: true
             manala_apt_packages:
+              - xz-utils
               - rsync
               - wget
               - curl


### PR DESCRIPTION
Now that apt role respect package installation order (https://github.com/manala/ansible-roles/pull/539), we could install xz-utils using provisionning