### PR TITLE
[Elao - App] Set grub device

### DIFF
--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -95,6 +95,15 @@ apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versi
   make \
   linux-image-amd64 linux-headers-amd64
 
+########
+# Grub #
+########
+
+printf "[\033[36mGrub\033[0m] \033[32mSet device...\033[0m\n"
+
+# See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=982182
+echo 'grub-pc grub-pc/install_devices multiselect /dev/sda' | debconf-set-selections
+
 ###########
 # Upgrade #
 ###########


### PR DESCRIPTION
Work around an open debian bug where grub panics during an update if the boot disk used during virtual machine image creation is not the same as the disk used during virtual machine running.

See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=982182

