### PR TITLE
[Elao - App] Fix docker build id

### DIFF
--- a/elao.app/.manala/docker/make.mk.tmpl
+++ b/elao.app/.manala/docker/make.mk.tmpl
@@ -20,6 +20,7 @@ define docker_run
 		docker build \
 			--quiet \
 			$(_ROOT_DIR)/.manala \
+		| head -n 1 \
 	) \
 	&& docker run \
 		--rm \


### PR DESCRIPTION
Symptoms:
```Building docker image...
/usr/local/bin/entrypoint.sh: line 26: exec: Use: not found
```

The facts: `docker build --quiet` command is supposed to write image id, and only image id on stdout. On a recent update docker adds some "marketing" stuff on a second line: `Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them`.

Treatment: just keep the first stdout line :)