### PR TITLE
[Elao - App] Organize make help commands by sections

### DIFF
--- a/elao.app/.manala/Makefile.tmpl
+++ b/elao.app/.manala/Makefile.tmpl
@@ -153,9 +153,3 @@ deploy{{ include "release_target" $release }}:
 {{ end }}
 
 {{- end -}}
-
-###########
-# Project #
-###########
-
-HELP += $(call help_section, Project)

--- a/elao.app/.manala/make/help.mk
+++ b/elao.app/.manala/make/help.mk
@@ -2,8 +2,10 @@
 # Help #
 ########
 
+.DEFAULT_GOAL := help
+
 HELP = \
-	\nUsage: make [$(COLOR_INFO)target$(COLOR_RESET)] \
+	\nUsage: make [$(COLOR_INFO)command$(COLOR_RESET)] \
 	$(call help_section, Help) \
 	$(call help,help,This help)
 
@@ -17,26 +19,50 @@ endef
 
 help:
 	@printf "$(HELP)$(HELP_SUFFIX)"
-	awk ' \
+	@awk ' \
+		BEGIN { \
+			sectionsName[1] = "Commands" ; \
+			sectionsCount = 1 ; \
+		} \
 		/^[-a-zA-Z0-9_.@%\/]+:/ { \
-			hasMessage = match(lastLine, /^## (.*)/); \
-			if (hasMessage) { \
-				lines++; \
-				helpCommands[lines] = substr($$1, 0, index($$1, ":")); \
-				helpLenght = length(helpCommands[lines]); \
-				if (helpLenght > helpLenghtMax) { \
-					helpLenghtMax = helpLenght; \
+			if (match(lastLine, /^## (.*)/)) { \
+				command = substr($$1, 1, index($$1, ":") - 1) ; \
+				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \
+				if (section) { \
+					message = substr(lastLine, index(lastLine, " - ") + 3, RLENGTH) ; \
+					sectionIndex = 0 ; \
+					for (i = 1; i <= sectionsCount; i++) { \
+						if (sectionsName[i] == section) { \
+							sectionIndex = i ; \
+						} \
+					} \
+					if (!sectionIndex) { \
+						sectionIndex = sectionsCount++ + 1 ; \
+						sectionsName[sectionIndex] = section ; \
+					} \
+				} else { \
+					message = substr(lastLine, RSTART + 3, RLENGTH) ; \
+					sectionIndex = 1 ; \
 				} \
-				helpMessages[lines] = substr(lastLine, RSTART + 3, RLENGTH); \
+				if (length(command) > sectionsCommandLength[sectionIndex]) { \
+					sectionsCommandLength[sectionIndex] = length(command) ; \
+				} \
+				sectionCommandIndex = sectionsCommandCount[sectionIndex]++ + 1; \
+				helpsCommand[sectionIndex, sectionCommandIndex] = command ; \
+				helpsMessage[sectionIndex, sectionCommandIndex] = message ; \
 			} \
 		} \
 		{ lastLine = $$0 } \
 		END { \
-			for (i = 1; i <= lines; i++) { \
-       			printf "\n  $(COLOR_INFO)%-" helpLenghtMax "s$(COLOR_RESET) %s", helpCommands[i], helpMessages[i]; \
-       		} \
+			for (i = 1; i <= sectionsCount; i++) { \
+				if (sectionsCommandCount[i]) { \
+					printf "\n\n$(COLOR_COMMENT)%s:$(COLOR_RESET)", sectionsName[i] ; \
+					for (j = 1; j <= sectionsCommandCount[i]; j++) { \
+						printf "\n  $(COLOR_INFO)%-" sectionsCommandLength[i] "s$(COLOR_RESET) %s", helpsCommand[i, j], helpsMessage[i, j] ; \
+					} \
+				} \
+			} \
 		} \
 	' $(MAKEFILE_LIST)
 	@printf "\n\n"
-
 .PHONY: help


### PR DESCRIPTION
Given following project `Makefile` commands:
```

## Foo
foo:
  ...

## Bar - Baz
bar.baz:
  ...

## Qux - Baz
qux.baz:
  ...

## Bar - Qux
bar.qux:
  ...

## Qux - Qux
qux.qux:
  ...
```

This pr tends to enhance commands helps visibility by grouping and ordering messages by "sections". Section names are parsed from messages themselves given the following pattern:

`[Section] - [Message]`

Example:

`## D'assaut - In a bottle`
* Section: "D'assault"
* Message: "In a bottle"

Where our old fashionned and ugly help command used to output this:
```
Usage: make [target]

Help:
  help This help

...

Project:
  foo:     Foo
  bar.baz: Bar - Baz
  qux.baz: Qux - Baz
  bar.qux: Bar - Qux
  qux.qux: Qux - Qux
```

We'll can finally face the challenges of the 21st century:
```
Usage: make [command]

Help:
  help This help

...

Commands:
  foo: Foo

Bar:
  bar.baz: Baz
  bar.qux: Qux

Qux:
  qux.baz: Baz
  qux.qux: Qux
```