### PR TITLE
[Elao - App] Fix apt update release info change

### DIFF
--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -80,7 +80,7 @@ apt-key adv --quiet --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1394DE
 
 printf "[\033[36mApt\033[0m] \033[32mUpdate...\033[0m\n"
 
-apt-get --quiet update
+apt-get --quiet --allow-releaseinfo-change update
 
 ##########
 # System #


### PR DESCRIPTION
Symptom:
```
$ make setup
...
    development: [Apt] Update...
    development: Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
    development: Get:2 http://httpredir.debian.org/debian buster InRelease [122 kB]
    development: Get:3 http://httpredir.debian.org/debian buster-updates InRelease [51.9 kB]
    development: Reading package lists...
    development: E
    development: :
    development: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
    development: E
    development: :
    development: Repository 'http://httpredir.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
    development: E
    development: :
    development: Repository 'http://httpredir.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
make: *** [setup] Error 1
```