### PR TITLE
[Elao - App] "--allow-releaseinfo-change" apt-get option unavailable on debian stretch

### DIFF
--- a/elao.app/.manala/vagrant/bin/setup.sh.tmpl
+++ b/elao.app/.manala/vagrant/bin/setup.sh.tmpl
@@ -80,7 +80,11 @@ apt-key adv --quiet --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 1394DE
 
 printf "[\033[36mApt\033[0m] \033[32mUpdate...\033[0m\n"
 
+{{ if eq (.version|int) 9 -}}
+apt-get --quiet update
+{{- else -}}
 apt-get --quiet --allow-releaseinfo-change update
+{{- end }}
 
 ##########
 # System #


### PR DESCRIPTION
"--allow-releaseinfo-change" apt-get option is unavailable on debian stretch

See:
- https://manpages.debian.org/buster/apt/apt-get.8.fr.html
- https://manpages.debian.org/buster/apt/apt-get.8.fr.html