### PR TITLE
[Lazy] Fix env handling

### DIFF
--- a/lazy.ansible/.manala/docker-compose.yaml.tmpl
+++ b/lazy.ansible/.manala/docker-compose.yaml.tmpl
@@ -22,7 +22,9 @@ services:
         environment:
             DIR: ${DIR}
             CACHE_DIR: ${CACHE_DIR}
+            {{- if .Vars.system.env }}
             {{- .Vars.system.env | toYaml | nindent 12 }}
+            {{- end }}
         {{- if .Vars.system.env_file }}
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:

--- a/lazy.kubernetes/.manala/docker-compose.yaml.tmpl
+++ b/lazy.kubernetes/.manala/docker-compose.yaml.tmpl
@@ -22,7 +22,9 @@ services:
         environment:
             DIR: ${DIR}
             CACHE_DIR: ${CACHE_DIR}
+            {{- if .Vars.system.env }}
             {{- .Vars.system.env | toYaml | nindent 12 }}
+            {{- end }}
         {{- if .Vars.system.env_file }}
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:

--- a/lazy.symfony/.manala/docker-compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker-compose.yaml.tmpl
@@ -95,7 +95,9 @@ services:
         environment:
             DIR: ${DIR}
             CACHE_DIR: ${CACHE_DIR}
+            {{- if .Vars.system.env }}
             {{- .Vars.system.env | toYaml | nindent 12 }}
+            {{- end }}
         {{- if .Vars.system.env_file }}
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:


### PR DESCRIPTION
Empty env dict produced an invalid docker-compose.yaml file (with a `{}`)