### PR TITLE
[Lazy] Update to debian bullseye

### DIFF
--- a/lazy.ansible/.manala/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-ARG DEBIAN=buster
+ARG DEBIAN=bullseye
 
 ########
 # Base #
@@ -26,7 +26,7 @@ RUN \
         curl \
         ca-certificates \
         gnupg \
-        bsdtar bzip2 \
+        libarchive-tools bzip2 \
         bash-completion \
         make \
         less \

--- a/lazy.kubernetes/.manala/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-ARG DEBIAN=buster
+ARG DEBIAN=bullseye
 
 ########
 # Base #
@@ -26,7 +26,7 @@ RUN \
         curl \
         ca-certificates \
         gnupg \
-        bsdtar bzip2 \
+        libarchive-tools bzip2 \
         bash-completion \
         make \
         less \

--- a/lazy.symfony/.manala/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-ARG DEBIAN=buster
+ARG DEBIAN=bullseye
 
 ########
 # Base #
@@ -26,7 +26,7 @@ RUN \
         curl \
         ca-certificates \
         gnupg \
-        bsdtar bzip2 \
+        libarchive-tools bzip2 \
         bash-completion \
         make \
         less \


### PR DESCRIPTION
Note that `bsdtar` package was a transition package, know available as `libarchive-tools`