### PR TITLE
[Lazy] Enable debian backports

### DIFF
--- a/lazy.ansible/.manala/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/Dockerfile.tmpl
@@ -20,7 +20,9 @@ ARG STARSHIP_VERSION=0.56.0
 ENV container="docker"
 
 RUN \
-    apt-get update \
+    # Backports
+    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         sudo \
         curl \

--- a/lazy.kubernetes/.manala/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/Dockerfile.tmpl
@@ -20,7 +20,9 @@ ARG STARSHIP_VERSION=0.56.0
 ENV container="docker"
 
 RUN \
-    apt-get update \
+    # Backports
+    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         sudo \
         curl \

--- a/lazy.symfony/.manala/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/Dockerfile.tmpl
@@ -20,7 +20,9 @@ ARG STARSHIP_VERSION=0.56.0
 ENV container="docker"
 
 RUN \
-    apt-get update \
+    # Backports
+    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         sudo \
         curl \


### PR DESCRIPTION
Some packages, such as pipx (https://packages.debian.org/bullseye-backports/pipx) are only available on backports for bullseye