### PR TITLE
[Elao - App - Docker] Releases to Deliveries

### DIFF
--- a/elao.app.docker/.manala.yaml
+++ b/elao.app.docker/.manala.yaml
@@ -176,45 +176,46 @@ system:
 # }
 integration: {}
 
-############
-# Releases #
-############
+##############
+# Deliveries #
+##############
 
 # @schema {
 #     "definitions": {
-#         "release": {"type": "object", "$id": "#release",
+#         "delivery": {"type": "object", "$id": "#delivery",
 #             "additionalProperties": false,
 #             "properties": {
 #                 "app": {"type": "string", "pattern": "^[a-z]+$"},
 #                 "tier": {"type": "string", "pattern": "^[\\w-/]+$"},
-#                 "repo": {"type": "string"},
 #                 "ref": {"type": "string", "pattern": "^[\\w-/]+$"},
-#                 "release_tasks": {"type": "array", "items": {"$ref": "#release_task"}},
+#                 "release_repo": {"type": "string"},
+#                 "release_ref": {"type": "string", "pattern": "^[\\w-/]+$"},
+#                 "release_tasks": {"type": "array", "items": {"$ref": "#delivery_task"}},
 #                 "release_add": {"type": "array", "items": {"type": "string"}},
-#                 "release_removed": {"type": "array", "items": {"type": "string"}},
-#                 "deploy_hosts": {"type": "array", "items": {"$ref": "#release_host"}},
+#                 "release_remove": {"type": "array", "items": {"type": "string"}},
+#                 "deploy_hosts": {"type": "array", "items": {"$ref": "#delivery_host"}},
 #                 "deploy_dir": {"type": "string"},
 #                 "deploy_releases": {"type": "integer"},
-#                 "deploy_tasks": {"type": "array", "items": {"$ref": "#release_task"}},
-#                 "deploy_post_tasks": {"type": "array", "items": {"$ref": "#release_task"}},
+#                 "deploy_tasks": {"type": "array", "items": {"$ref": "#delivery_task"}},
+#                 "deploy_post_tasks": {"type": "array", "items": {"$ref": "#delivery_task"}},
 #                 "deploy_shared_files": {"type": "array", "items": {"type": "string"}},
 #                 "deploy_shared_dirs": {"type": "array", "items": {"type": "string"}},
 #                 "deploy_writable_dirs": {"type": "array", "items": {"type": "string"}},
-#                 "deploy_removed": {"type": "array", "items": {"type": "string"}}
+#                 "deploy_remove": {"type": "array", "items": {"type": "string"}}
 #             },
 #             "dependencies": {
 #                 "deploy_hosts": ["deploy_dir"]
 #             },
-#             "required": ["tier", "repo"]
+#             "required": ["tier"]
 #         },
-#         "release_task": {"type": "object", "$id": "#release_task",
+#         "delivery_task": {"type": "object", "$id": "#delivery_task",
 #             "additionalProperties": false,
 #             "properties": {
 #                 "shell": {"type": "string"},
 #                 "when": {"type": "string"}
 #             }
 #         },
-#         "release_host": {"type": "object", "$id": "#release_host",
+#         "delivery_host": {"type": "object", "$id": "#delivery_host",
 #             "additionalProperties": true,
 #             "properties": {
 #                 "ssh_host": {"type": "string", "format": "hostname"},
@@ -224,6 +225,6 @@ integration: {}
 #             "required": ["ssh_host"]
 #         }
 #     },
-#     "items": {"$ref": "#release"}
+#     "items": {"$ref": "#delivery"}
 # }
-releases: []
+deliveries: []

--- a/elao.app.docker/.manala/Makefile.tmpl
+++ b/elao.app.docker/.manala/Makefile.tmpl
@@ -130,34 +130,34 @@ provision.certificates: _ANSIBLE_PLAYBOOK_TAGS = certificates
 provision.certificates: _ANSIBLE_PLAYBOOK_EXTRA_VARS = certificates_prompt=true
 provision.certificates: provision
 
-{{ if .Vars.releases -}}
-############
-# Releases #
-############
+{{ if .Vars.deliveries -}}
+##############
+# Deliveries #
+##############
 
-HELP += $(call help_section, Releases)
+HELP += $(call help_section, Deliveries)
 
-{{ range $release := .Vars.releases }}
+{{ range $delivery := .Vars.deliveries }}
 
-{{- if or (hasKey $release "release_tasks") (hasKey $release "release_add") (hasKey $release "release_removed") -}}
-HELP += $(call help,release{{ include "release_target" $release }},Release {{ include "release_help" $release }})
-release{{ include "release_target" $release }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
-release{{ include "release_target" $release }}: _ANSIBLE_PLAYBOOK_INVENTORY = $(_DIR)/.manala/ansible/inventories/release.yaml
-release{{ include "release_target" $release }}: _ANSIBLE_PLAYBOOK_LIMIT = {{ include "release_group" . }}
-release{{ include "release_target" $release }}:
+{{- if hasKey $delivery "release_repo" -}}
+HELP += $(call help,release{{ include "delivery_target" $delivery }},Release {{ include "delivery_help" $delivery }})
+release{{ include "delivery_target" $delivery }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
+release{{ include "delivery_target" $delivery }}: _ANSIBLE_PLAYBOOK_INVENTORY = $(_DIR)/.manala/ansible/inventories/release.yaml
+release{{ include "delivery_target" $delivery }}: _ANSIBLE_PLAYBOOK_LIMIT = {{ include "delivery_group" . }}
+release{{ include "delivery_target" $delivery }}:
 	$(call log, Run ansible playbook)
 	$(_ansible_playbook) \
 		$(_DIR)/.manala/ansible/release.yaml
 
 {{ end -}}
 
-{{- if hasKey $release "deploy_hosts" -}}
-HELP += $(call help,deploy{{ include "release_target" $release }},Deploy {{ include "release_help" $release }} (REF))
-deploy{{ include "release_target" $release }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
-deploy{{ include "release_target" $release }}: _ANSIBLE_PLAYBOOK_INVENTORY = $(_DIR)/.manala/ansible/inventories/deploy.yaml
-deploy{{ include "release_target" $release }}: _ANSIBLE_PLAYBOOK_LIMIT = {{ include "release_group" $release }}
-deploy{{ include "release_target" $release }}: _ANSIBLE_PLAYBOOK_EXTRA_VARS = $(if $(REF),'{"deploy_strategy_git_ref": "$(REF)"}')
-deploy{{ include "release_target" $release }}:
+{{- if hasKey $delivery "deploy_hosts" -}}
+HELP += $(call help,deploy{{ include "delivery_target" $delivery }},Deploy {{ include "delivery_help" $delivery }} (REF))
+deploy{{ include "delivery_target" $delivery }}: SHELL := $(or $(DOCKER_SHELL),$(SHELL))
+deploy{{ include "delivery_target" $delivery }}: _ANSIBLE_PLAYBOOK_INVENTORY = $(_DIR)/.manala/ansible/inventories/deploy.yaml
+deploy{{ include "delivery_target" $delivery }}: _ANSIBLE_PLAYBOOK_LIMIT = {{ include "delivery_group" $delivery }}
+deploy{{ include "delivery_target" $delivery }}: _ANSIBLE_PLAYBOOK_EXTRA_VARS = $(if $(REF),'{"deploy_strategy_git_ref": "$(REF)"}')
+deploy{{ include "delivery_target" $delivery }}:
 	$(call log, Run ansible playbook)
 	$(_ansible_playbook) \
 		$(_DIR)/.manala/ansible/deploy.yaml

--- a/elao.app.docker/.manala/ansible/inventories/deploy.yaml.tmpl
+++ b/elao.app.docker/.manala/ansible/inventories/deploy.yaml.tmpl
@@ -1,12 +1,12 @@
 deploy:
     children:
-    {{- range $release := .Vars.releases }}
-    {{- if hasKey $release "deploy_hosts" }}
+    {{- range $delivery := .Vars.deliveries }}
+    {{- if hasKey $delivery "deploy_hosts" }}
 
-        {{ include "release_group" $release }}:
+        {{ include "delivery_group" $delivery }}:
             hosts:
-            {{- range $index, $host := $release.deploy_hosts }}
-                {{ (add $index 1) | printf "%02d" }}{{ include "release_host" $release }}:
+            {{- range $index, $host := $delivery.deploy_hosts }}
+                {{ (add $index 1) | printf "%02d" }}{{ include "delivery_host" $delivery }}:
                     # Ansible
                     ansible_host: {{ $host.ssh_host }}
                     {{- if hasKey $host "ssh_user" }}
@@ -22,26 +22,26 @@ deploy:
                     {{- end }}
             {{- end }}
             vars:
-                deploy_releases: {{ if hasKey $release "deploy_releases" }}{{ $release.deploy_releases }}{{ else }}3{{ end }}
+                deploy_releases: {{ if hasKey $delivery "deploy_releases" }}{{ $delivery.deploy_releases }}{{ else }}3{{ end }}
                 deploy_strategy: git
-                deploy_strategy_git_repo: {{ $release.repo }}
-                deploy_strategy_git_ref: {{ if hasKey $release "ref" }}
-                  {{- $release.ref }}
+                deploy_strategy_git_repo: {{ $delivery.release_repo }}
+                deploy_strategy_git_ref: {{ if hasKey $delivery "release_ref" }}
+                  {{- $delivery.release_ref }}
                 {{- else }}
-                  {{- if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.tier }}
+                  {{- if hasKey $delivery "app" }}{{ $delivery.app }}/{{ end }}{{ $delivery.tier }}
                 {{- end }}
-                deploy_dir: {{ $release.deploy_dir }}
-                {{- if hasKey $release "deploy_tasks" }}
+                deploy_dir: {{ $delivery.deploy_dir }}
+                {{- if hasKey $delivery "deploy_tasks" }}
                 deploy_tasks:
-                    {{- include "release_tasks" $release.deploy_tasks | nindent 20 }}
+                    {{- include "delivery_tasks" $delivery.deploy_tasks | nindent 20 }}
                 {{- end }}
-                {{- if hasKey $release "deploy_post_tasks" }}
+                {{- if hasKey $delivery "deploy_post_tasks" }}
                 deploy_post_tasks:
-                    {{- include "release_tasks" $release.deploy_post_tasks | nindent 20 }}
+                    {{- include "delivery_tasks" $delivery.deploy_post_tasks | nindent 20 }}
                 {{- end }}
-                {{- $release = pick $release "deploy_shared_files" "deploy_shared_dirs" "deploy_writable_dirs" "deploy_removed" -}}
-                {{- if $release }}
-                {{- $release | toYaml | nindent 16 }}
+                {{- $delivery = pick $delivery "deploy_shared_files" "deploy_shared_dirs" "deploy_writable_dirs" "deploy_remove" -}}
+                {{- if $delivery }}
+                {{- $delivery | toYaml | nindent 16 }}
                 {{- end }}
     {{- end }}
     {{- end }}

--- a/elao.app.docker/.manala/ansible/inventories/release.yaml.tmpl
+++ b/elao.app.docker/.manala/ansible/inventories/release.yaml.tmpl
@@ -1,31 +1,31 @@
 release:
     children:
-    {{- range $release := .Vars.releases }}
-    {{- if or (hasKey $release "release_tasks") (hasKey $release "release_add") (hasKey $release "release_removed") }}
+    {{- range $delivery := .Vars.deliveries }}
+    {{- if hasKey $delivery "release_repo" }}
 
-        {{ include "release_group" $release }}:
+        {{ include "delivery_group" $delivery }}:
             hosts:
-                localhost{{ include "release_host" $release }}:
+                localhost{{ include "delivery_host" $delivery }}:
                     ansible_connection: local
             vars:
-                release_dir: /srv/release/{{ if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.tier }}
+                release_dir: /srv/release/{{ if hasKey $delivery "app" }}{{ $delivery.app }}/{{ end }}{{ $delivery.tier }}
                 release_git_dir: /srv/app
-                {{- if hasKey $release "app" }}
-                release_target_dir: {{ $release.app }}
+                {{- if hasKey $delivery "app" }}
+                release_target_dir: {{ $delivery.app }}
                 {{- end }}
-                release_repo: {{ $release.repo }}
-                release_version: {{ if hasKey $release "ref" }}
-                  {{- $release.ref }}
+                release_repo: {{ $delivery.release_repo }}
+                release_ref: {{ if hasKey $delivery "release_ref" }}
+                  {{- $delivery.release_ref }}
                 {{- else }}
-                  {{- if hasKey $release "app" }}{{ $release.app }}/{{ end }}{{ $release.tier }}
+                  {{- if hasKey $delivery "app" }}{{ $delivery.app }}/{{ end }}{{ $delivery.tier }}
                 {{- end }}
-                {{- if hasKey $release "release_tasks" }}
+                {{- if hasKey $delivery "release_tasks" }}
                 release_tasks:
-                    {{- include "release_tasks" $release.release_tasks | nindent 18 }}
+                    {{- include "delivery_tasks" $delivery.release_tasks | nindent 18 }}
                 {{- end }}
-                {{- $release = pick $release "release_removed" "release_add" -}}
-                {{- if $release }}
-                {{- $release | toYaml | nindent 16 }}
+                {{- $delivery = pick $delivery "release_remove" "release_add" -}}
+                {{- if $delivery }}
+                {{- $delivery | toYaml | nindent 16 }}
                 {{- end }}
     {{- end }}
     {{- end }}

--- a/elao.app.docker/.manala/ansible/roles/deploy/defaults/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/deploy/defaults/main.yml
@@ -34,8 +34,8 @@ deploy_shared_dirs:  []
 # Copied
 deploy_copied: []
 
-# Removed
-deploy_removed: []
+# Remove
+deploy_remove: []
 
 # Writable
 deploy_writable_dirs_default: # Ensure backward compatibility

--- a/elao.app.docker/.manala/ansible/roles/deploy/tasks/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/deploy/tasks/main.yml
@@ -48,12 +48,12 @@
   loop: "{{ query('deploy_tasks', deploy_tasks) }}"
   when: item.when
 
-# Removed
-- name: removed > Files
+# Remove
+- name: remove > Files
   file:
     path:  "{{ deploy_helper.new_release_path ~ '/' ~ item }}"
     state: absent
-  with_items: "{{ deploy_removed }}"
+  with_items: "{{ deploy_remove }}"
 
 # Finalize
 - name: finalize > Remove the unfinished file and create a symlink to the newly deployed release

--- a/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
@@ -7,16 +7,14 @@ release_target_dir: ~
 # Git
 release_git_dir: ~
 release_repo:    ~
-release_version: master
+release_ref: master
 
 # Tasks
 release_tasks: []
 
-# Removed
-release_removed: []
-
-# Add
+# Add / Remove
 release_add: []
+release_remove: []
 
 # Regex (protocol|host|user|repository)
 release_git_url_regex: '^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repository>.+).git$'

--- a/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
@@ -44,17 +44,17 @@
   loop: "{{ query('release_tasks', release_tasks) }}"
   when: item.when
 
-- name: git > Init "{{ release_repo }}" on branch "{{ release_version }}"
+- name: git > Init "{{ release_repo }}" on branch "{{ release_ref }}"
   ansible.builtin.shell: >
     git init
-    && git checkout -b {{ release_version }}
+    && git checkout -b {{ release_ref }}
     && git remote add origin {{ release_repo }}
     && git fetch
     && (
-      git show-ref -q origin/{{ release_version }} ; rc=$? ;
+      git show-ref -q origin/{{ release_ref }} ; rc=$? ;
       if [ $rc -eq 0 -o $rc -eq 1 ] ; then
         if [ $rc -eq 0 ] ; then
-          git update-ref HEAD origin/{{ release_version }} ;
+          git update-ref HEAD origin/{{ release_ref }} ;
         fi ;
       else
         return $rc ;
@@ -70,7 +70,7 @@
   args:
     warn: false
   tags: log_failed
-  loop: "{{ release_removed }}"
+  loop: "{{ release_remove }}"
 
 - name: git > Add all
   ansible.builtin.shell: >
@@ -105,9 +105,9 @@
     chdir: "{{ release_dir }}"
   tags: log_failed
 
-- name: git > Push "{{ release_version }}"
+- name: git > Push "{{ release_ref }}"
   ansible.builtin.shell: >
-    git push --set-upstream origin {{ release_version }}
+    git push --set-upstream origin {{ release_ref }}
     && git push origin HEAD
   args:
     chdir: "{{ release_dir }}"

--- a/elao.app.docker/MIGRATION.2022-02.md
+++ b/elao.app.docker/MIGRATION.2022-02.md
@@ -270,15 +270,42 @@ system:
                     error_log /srv/log/nginx.error.log;
 ```
 
-### Releases
+### Releases / Deliveries
 
-`mode` key has been renamed to `tier` in `.manala.yaml`.
+"Releases" have been renamed to "Deliveries"
+
+Somes keys have also been renamed in `.manala.yaml`:
+- `mode` -> `tier`
+- `repo` -> `release_repo`
+- `ref` -> `release_ref`
+- `release_removed` -> `release_remove`
+- `deploy_removed` -> `deploy_remove`
 
 ```diff
-releases:
-  - ...
+- ############
+- # Releases #
+- ############
+
+- releases:
++ ##############
++ # Deliveries #
++ ##############
+
++ deliveries:
+- - &release_foo_bar
++ - &delivery_foo_bar
+    ...
 -   mode: production
 +   tier: production
+-   repo: git@git.example.com:foo/bar.git
+-   ref: staging
+    # Release
++   release_repo: git@git.example.com:foo/bar.git
++   release_ref: staging
+-   release_removed: [...]
++   release_remove: [...]
+-   deploy_removed: [...]
++   deploy_remove: [...]
     ...
 ```
 

--- a/elao.app.docker/README.md
+++ b/elao.app.docker/README.md
@@ -43,7 +43,7 @@ Edit the `Makefile` at the root directory of your project and add the following 
 -include .manala/Makefile
 ```
 
-Then update the `.manala.yaml` file (see [the releases example](#releases) below) and then run the `manala up` command:
+Then update the `.manala.yaml` file (see [the deliveries example](#deliveries) below) and then run the `manala up` command:
 
 ```shell
 manala up
@@ -474,23 +474,24 @@ test.jest@integration:
 
 ```
 
-## Releases
+## Deliveries
 
-Here is an example of a production/staging release configuration in `.manala.yaml`:
+Here is an example of a production/staging deliveries configuration in `.manala.yaml`:
 
 ```yaml
-############
-# Releases #
-############
+##############
+# Deliveries #
+##############
 
-releases:
+deliveries:
 
-  - &release
+  - &delivery
     #app: api # Optional
     tier: production
-    repo: git@git.elao.com:<vendor>/<app>-release.git
-    #ref: master # Based on app/tier by default
+    #ref: staging # Default to master
     # Release
+    release_repo: git@git.example.com:<vendor>/<app>-release.git
+    #release_ref: master # Based on app/tier by default
     release_tasks:
       - shell: make install@production
       - shell: make build@production
@@ -508,7 +509,7 @@ releases:
       - Makefile
 
     # Or you can include all by default and only list the paths you want to exclude
-    # release_removed:
+    # release_remove:
     #   - ansible
     #   - build
     #   - doc
@@ -537,13 +538,13 @@ releases:
       - shell: make warmup@production
       #- shell: make migration@production
       #  when: master | default # Conditions on custom host variables (jinja2 format)
-    #deploy_removed:
+    #deploy_remove:
     #  - web/app_dev.php
     deploy_post_tasks:
       - shell: sudo /bin/systemctl reload php8.1-fpm
       #- shell: sudo /bin/systemctl restart supervisor
 
-  - << : *release
+  - << : *delivery
     tier: staging
     release_tasks:
       - shell: make install@staging
@@ -715,7 +716,7 @@ parameters:
 See [Go Template syntax](https://docs.gomplate.ca/syntax/) for more info.
 
 !!! Warning
-    Make sure to include the `secrets` directory into your release, using the `release_add` entry.
+    Make sure to include the `secrets` directory into your deliveries, using the `release_add` entry.
 
 ## Https
 

--- a/elao.app.docker/_helpers.tmpl
+++ b/elao.app.docker/_helpers.tmpl
@@ -1,31 +1,31 @@
-{{/* Release makefile target */}}
-{{ define "release_target" -}}
+{{/* Delivery makefile target */}}
+{{ define "delivery_target" -}}
     {{- if hasKey . "app" }}.{{ .app }}{{ end -}}
     @
     {{- .tier }}
 {{- end }}
 
-{{/* Release makefile help */}}
-{{ define "release_help" -}}
+{{/* Delivery makefile help */}}
+{{ define "delivery_help" -}}
     {{- if hasKey . "app" }}{{ .app }} {{ end -}}
     in {{ .tier }}
 {{- end }}
 
-{{/* Release ansible group */}}
-{{ define "release_group" -}}
+{{/* Delivery ansible group */}}
+{{ define "delivery_group" -}}
     {{- if hasKey . "app" }}{{ .app }}_{{ end -}}
     {{- regexReplaceAll "[^[:alnum:]_]" .tier "_" }}
 {{- end }}
 
-{{/* Release ansible host */}}
-{{ define "release_host" -}}
+{{/* Delivery ansible host */}}
+{{ define "delivery_host" -}}
     {{- if hasKey . "app" }}.{{ .app }}{{ end -}}
     @
     {{- .tier }}
 {{- end }}
 
-{{/* Release ansible tasks */}}
-{{- define "release_tasks" -}}
+{{/* Delivery ansible tasks */}}
+{{- define "delivery_tasks" -}}
     {{- $tasks := list -}}
     {{- range $task := . -}}
       {{- if hasKey $task "when" -}}


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ ⚠️ 
BC BREAKS !!!
⚠️ ⚠️ ⚠️ ⚠️ 

"Releases" has been renamaed as "Deliveries"

Somes keys have also been renamed:
- `mode` -> `tier`
- `repo` -> `release_repo`
- `ref` -> `release_ref`
- `release_removed` -> `release_remove`
- `deploy_removed` -> `deploy_remove`

in `.manala.yaml`:
```diff
- ############
- # Releases #
- ############

- releases:
+ ##############
+ # Deliveries #
+ ##############

+ deliveries:
- - &release_foo_bar
+ - &delivery_foo_bar
    ...
-   mode: production
+   tier: production
-   repo: git@git.example.com:foo/bar.git
-   ref: staging
    # Release
+   release_repo: git@git.example.com:foo/bar.git
+   release_ref: staging
-   release_removed: [...]
+   release_remove: [...]
-   deploy_removed: [...]
+   deploy_remove: [...]
    ...
```