### PR TITLE
[Elao - App - Docker] Yarn on-demand

### DIFF
--- a/elao.app.docker/.manala.yaml
+++ b/elao.app.docker/.manala.yaml
@@ -105,6 +105,9 @@ system:
         version: ~
         # @schema {"items": {"type": "object"}}
         packages: []
+        yarn:
+          # @schema {"enum": [null, 1]}
+          version: ~
     mariadb:
         # @option {"label": "MariaDB version"}
         # @schema {"enum": [null, 10.6, 10.5, 10.4, 10.3, 10.2, 10.1]}

--- a/elao.app.docker/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app.docker/.manala/ansible/inventories/system.yaml.tmpl
@@ -80,7 +80,7 @@ system:
         system_nodejs_version: {{ .Vars.system.nodejs.version | toYaml }}
         system_nodejs_npm: {{ `"{{ system_nodejs }}"` }}
         {{- dict "system_nodejs_packages" .Vars.system.nodejs.packages | toYaml | nindent 8 }}
-        system_nodejs_yarn: {{ `"{{ system_nodejs }}"` }}
+        system_nodejs_yarn: {{ not (empty .Vars.system.nodejs.yarn.version) | ternary "true" "false" }}
         # Oh my zsh
         system_ohmyzsh: false
         # Php

--- a/elao.app.docker/MIGRATION.2022-02.md
+++ b/elao.app.docker/MIGRATION.2022-02.md
@@ -270,6 +270,19 @@ system:
                     error_log /srv/log/nginx.error.log;
 ```
 
+### Yarn
+
+Yarn is no more installed by default with nodejs. If you need it, in `.manala.yaml`:
+
+```yaml
+system:
+    ...
+    nodejs:
+        ...
+        yarn:
+            version: 1
+```
+
 ### Integration - Jenkins
 
 Jenkins integration pipeline has now its dedicated entry in `.manala.yaml`:

--- a/elao.app.docker/README.md
+++ b/elao.app.docker/README.md
@@ -200,6 +200,8 @@ system:
         # packages:
         #   - package: mjml
         #     version: 4.6.3
+        # yarn:
+        #     version: 1
     # cron:
     #     files:
     #       - file: app


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ 
BC BREAK
⚠️ ⚠️ ⚠️ 

Yarn version 1 (aka. "classic", the only version we support) is in maintenance mode since 2020 (see: https://classic.yarnpkg.com/lang/en/docs/install)
Yarn version 2+ is a p**n in the a*s to install (see: https://yarnpkg.com/getting-started/install)

with this pr, yarn is no more installed by default with nodejs , as an encouragement to STOP using it.

However, one can force its installation if necessary in `.manala.yaml`:
```yaml
system:
    ...
    nodejs:
        ...
        yarn:
            version: 1
