### PR TITLE
[Elao - App - Docker] Fix ssh-agent

### DIFF
--- a/elao.app.docker/.manala/docker/make.mk
+++ b/elao.app.docker/.manala/docker/make.mk
@@ -55,17 +55,14 @@ ifdef DEBUG
 _DOCKER_COMPOSE_ENV += BUILDKIT_PROGRESS=plain
 endif
 
-# MacOS
-ifdef OS_DARWIN
-# See: https://docs.docker.com/desktop/mac/networking/#ssh-agent-forwarding
-SSH_AUTH_SOCK = /run/host-services/ssh-auth.sock
-_DOCKER_COMPOSE_ENV += MANALA_SSH_AUTH_SOCK_BIND=$(SSH_AUTH_SOCK).bind
-endif
-
 # Ssh Agent
 ifdef SSH_AUTH_SOCK
 _DOCKER_COMPOSE_FILE += $(_DIR)/.manala/docker/compose/ssh-agent.yaml
-_DOCKER_COMPOSE_ENV += SSH_AUTH_SOCK=$(SSH_AUTH_SOCK)
+	# See: https://docs.docker.com/desktop/mac/networking/#ssh-agent-forwarding
+	ifdef OS_DARWIN
+_DOCKER_COMPOSE_ENV += SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+_DOCKER_COMPOSE_ENV += MANALA_SSH_AUTH_SOCK_BIND=/run/host-services/ssh-auth.sock.bind
+	endif
 endif
 
 # Internal usage:


### PR DESCRIPTION
That was not an easy one, thx @ogizanagi for report.

In a nutshell, by overriding `SSH_AUTH_SOCK` (to handle docker for mac peculiarities, see https://docs.docker.com/desktop/mac/networking/#ssh-agent-forwarding) every single command related to ssh-agent, and runned inside a makefile target had the wrong host `SSH_AUTH_SOCK` value...

This pr respect the same behavior, but in a way that don't globally override `SSH_AUTH_SOCK`. To be more specific, its override it * only * for the docker command itself.
