### PR TITLE
[Elao - App - Docker] Fix plugin already installed

### DIFF
--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -65,7 +65,7 @@ services:
             http.cors.enabled: "true"
         command: >
             sh -c
-            "{{- range $plugin := $.Vars.system.elasticsearch.plugins }}elasticsearch-plugin install --batch --verbose {{ $plugin }} && {{ end -}}
+            "{{- range $plugin := $.Vars.system.elasticsearch.plugins }}((elasticsearch-plugin list|grep {{ $plugin }}) || elasticsearch-plugin install --batch --verbose {{ $plugin }}) && {{ end -}}
             exec docker-entrypoint.sh"
         network_mode: service:app
         healthcheck:


### PR DESCRIPTION
L'installation des plugins elasticsearch se faisant à l'entrypoint du container, si le plugin est déjà installé, on obtient l'erreur suivante à chaque destroy/setup, car le container est gardé en cache et possède déjà le plugin :

> ERROR: plugin directory [/usr/share/elasticsearch/plugins/analysis-icu] already exists; if you need to update the plugin, uninstall it first using command ‘remove analysis-icu’

empêchant elasticsearch de démarrer.

Corrige en vérifiant la présence du plugin avec `elasticsearch-plugin list` avant l'installation.