### PR TITLE
[All] Allow + signs in targets appearing in help

### DIFF
--- a/elao.app.docker/.manala/make/help.mk
+++ b/elao.app.docker/.manala/make/help.mk
@@ -24,7 +24,7 @@ help:
 			sectionsName[1] = "Commands" ; \
 			sectionsCount = 1 ; \
 		} \
-		/^[-a-zA-Z0-9_.@%\/]+:/ { \
+		/^[-a-zA-Z0-9_.@%\/+]+:/ { \
 			if (match(lastLine, /^## (.*)/)) { \
 				command = substr($$1, 1, index($$1, ":") - 1) ; \
 				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \

--- a/elao.app/.manala/make/help.mk
+++ b/elao.app/.manala/make/help.mk
@@ -24,7 +24,7 @@ help:
 			sectionsName[1] = "Commands" ; \
 			sectionsCount = 1 ; \
 		} \
-		/^[-a-zA-Z0-9_.@%\/]+:/ { \
+		/^[-a-zA-Z0-9_.@%\/+]+:/ { \
 			if (match(lastLine, /^## (.*)/)) { \
 				command = substr($$1, 1, index($$1, ":") - 1) ; \
 				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \

--- a/lazy.ansible/.manala/make/help.mk
+++ b/lazy.ansible/.manala/make/help.mk
@@ -24,7 +24,7 @@ help:
 			sectionsName[1] = "Commands" ; \
 			sectionsCount = 1 ; \
 		} \
-		/^[-a-zA-Z0-9_.@%\/]+:/ { \
+		/^[-a-zA-Z0-9_.@%\/+]+:/ { \
 			if (match(lastLine, /^## (.*)/)) { \
 				command = substr($$1, 1, index($$1, ":") - 1) ; \
 				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \

--- a/lazy.kubernetes/.manala/make/help.mk
+++ b/lazy.kubernetes/.manala/make/help.mk
@@ -24,7 +24,7 @@ help:
 			sectionsName[1] = "Commands" ; \
 			sectionsCount = 1 ; \
 		} \
-		/^[-a-zA-Z0-9_.@%\/]+:/ { \
+		/^[-a-zA-Z0-9_.@%\/+]+:/ { \
 			if (match(lastLine, /^## (.*)/)) { \
 				command = substr($$1, 1, index($$1, ":") - 1) ; \
 				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \

--- a/lazy.symfony/.manala/make/help.mk
+++ b/lazy.symfony/.manala/make/help.mk
@@ -24,7 +24,7 @@ help:
 			sectionsName[1] = "Commands" ; \
 			sectionsCount = 1 ; \
 		} \
-		/^[-a-zA-Z0-9_.@%\/]+:/ { \
+		/^[-a-zA-Z0-9_.@%\/+]+:/ { \
 			if (match(lastLine, /^## (.*)/)) { \
 				command = substr($$1, 1, index($$1, ":") - 1) ; \
 				section = substr(lastLine, RSTART + 3, index(lastLine, " - ") - 4) ; \


### PR DESCRIPTION
so targets such as `run-ios-device+release@production` are not ignored