### PR TITLE
[Elao - App - Docker] Remove docker compose version

### DIFF
--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
     {{- if .Vars.system.mysql.version }}

--- a/elao.app.docker/.manala/docker/compose/development.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose/development.yaml.tmpl
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
     ###########

--- a/elao.app.docker/.manala/docker/compose/integration.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose/integration.yaml.tmpl
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
     #######

--- a/elao.app.docker/.manala/docker/compose/mutagen.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose/mutagen.yaml.tmpl
@@ -1,5 +1,3 @@
-version: "3.8"
-
 volumes:
     app:
 


### PR DESCRIPTION
As spotted in https://github.com/compose-spec/compose-spec/pull/206/files#diff-5f5b95e68cadf606dc6b4956ca67b87039e3283cb01aa3208fda399abc167906R11 this is no longer necessary with docker compose v2