### PR TITLE
[PhpRedisAdmin] Start optionnal

### DIFF
--- a/elao.app/.manala.yaml
+++ b/elao.app/.manala.yaml
@@ -123,6 +123,7 @@ system:
         # @schema {"enum": [null, "*"]}
         version: ~
         config: {}
+        phpredisadmin: true
     elasticsearch:
         # @option {"label": "Elasticsearch version"}
         # @schema {"enum": [null, 7, 6, 5, 2, 1.7, 1.6, 1.5]}

--- a/elao.app/.manala/ansible/inventories/system.yaml.tmpl
+++ b/elao.app/.manala/ansible/inventories/system.yaml.tmpl
@@ -105,6 +105,7 @@ system:
         # Redis
         system_redis: false
         system_redis_version: {{ .redis.version | toYaml }}
+        system_redis_phpredisadmin: {{ .redis.phpredisadmin | toYaml }}
         {{- dict "system_redis_server_config" .redis.config | toYaml | nindent 8 }}
         # Ssh
         system_ssh: false

--- a/elao.app/.manala/ansible/system.yaml
+++ b/elao.app/.manala/ansible/system.yaml
@@ -187,7 +187,7 @@
           - 1979:80
       - name: phpredisadmin
         image: erikdubbelboer/phpredisadmin
-        state: "{{ 'started' if (system_redis) else 'absent' }}"
+        state: "{{ 'started' if ((system_redis) and (system_redis_phpredisadmin)) else 'absent' }}"
         restart_policy: unless-stopped
         env:
           # Default docker host ip


### PR DESCRIPTION
The need is to be able to not start the default PhpRedisAdmin container, so we can start another one with custom env to authenticate, in case authentication is set on redis server.