### PR TITLE
[Elao - App - Docker] Fix nginx 404 file permissions

### DIFF
--- a/elao.app.docker/.manala/ansible/system.yaml
+++ b/elao.app.docker/.manala/ansible/system.yaml
@@ -139,9 +139,13 @@
         state: directory
       - path: "{{ system_app_release_dir }}"
         state: directory
+      - path: /usr/share/nginx/html
+        state: directory
+        mode: "0755"
       - path: /usr/share/nginx/html/404.html
         template: nginx/html/404.html.j2
         mode: "0644"
+        parents: false
       - "{{ system_files_attributes }}"
 
     #######


### PR DESCRIPTION
Symptom: you get a 403 from nginx, which is in fact a 404, but nginx don't have the permission to get 404.html file to show you that it's a 404, so you get a 403...

```
⇒  ls -lsa /usr/share/nginx
ls: cannot access '/usr/share/nginx/html': Permission denied
ls: cannot access '/usr/share/nginx/..': Permission denied
ls: cannot access '/usr/share/nginx/.': Permission denied
total 0
? d????????? ? ? ? ?            ? .
? d????????? ? ? ? ?            ? ..
? d????????? ? ? ? ?            ? html
```

In fact, `files` role is played before `nginx` one, so that `/usr/share/nginx` folder does not yet exists. No matter, you will say, `files` role will create it for us
And yes, for sure, it will create it for us, but with the given file permissions, "0644"...

I remember one of my old friends saying "you will never get good things from folders without the execution flag". Damn he was so right...