### PR TITLE
[elao.app.docker] Provide a way to forwards secrets as env vars during release/deploy

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -74,6 +74,9 @@ jobs:
           ref: {{ `${{ github.event.inputs.ref }}` }}
           release: true
           deploy: {{ `${{ github.event.inputs.deploy }}` }}
+          #env: |
+          #  {{ `SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \` }}
+          #  {{ `COMPOSER_AUTH=${{ secrets.COMPOSER_AUTH }}` }}
 ```
 
 `.github/workflows/deploy.yaml`:
@@ -121,6 +124,48 @@ jobs:
           release: false
           deploy: true
           deploy_ref: {{ `${{ github.event.inputs.ref }}` }}
+```
+
+### Exposing secrets
+
+In case you need to expose secrets as env vars, for instance to provide an auth token during the release process,
+you can use the `with.env` key to provide a string of env vars to be forwarded, as shown above.
+
+Use Github [steps conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif) in order to expose different secrets depending on the app / tier:
+
+```yaml
+jobs:
+  release:
+    # […]
+    steps:
+      # […]
+      - name: Staging Release
+        uses: ./.manala/github/deliveries
+        if: {{ `${{ github.event.inputs.tier == 'staging' }}` }}
+        with:
+          secrets: {{ `${{ toJSON(secrets) }}` }}
+          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }}` }}
+          {{- if $apps }}
+          app: {{ `${{ github.event.inputs.app }}` }}
+          {{- end }}
+          tier: staging
+          ref: {{ `${{ github.event.inputs.ref }}` }}
+          release: true
+          deploy: {{ `${{ github.event.inputs.deploy }}` }}
+
+      - name: Production Release
+        uses: ./.manala/github/deliveries
+        if: {{ `${{ github.event.inputs.tier == 'production' }}` }}
+        with:
+          secrets: {{ `${{ toJSON(secrets) }}` }}
+          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.PRODUCTION_SENTRY_AUTH_TOKEN }}` }}
+          {{- if $apps }}
+          app: {{ `${{ github.event.inputs.app }}` }}
+          {{- end }}
+          tier: production
+          ref: {{ `${{ github.event.inputs.ref }}` }}
+          release: true
+          deploy: {{ `${{ github.event.inputs.deploy }}` }}
 ```
 
 {{- end }}

--- a/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
@@ -26,6 +26,10 @@ inputs:
   deploy_ref:
     description: Deploy Ref
     required: false
+  env:
+    description: Env vars as a single string
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -71,7 +75,8 @@ runs:
         shell_group: 📦 Release
         shell: |
           make release{{ include "delivery_target" $delivery }} \
-            AUTHOR="manala-ci-releaser <{{ `${{ github.actor }}` }}+github@manala.io>"
+            AUTHOR="manala-ci-releaser <{{ `${{ github.actor }}` }}+github@manala.io>" \
+            {{ `${{ inputs.env }}` }}
 
     - name: Create {{ $delivery_name }} GitHub Deployment
       if: >
@@ -100,7 +105,8 @@ runs:
         shell_group: 🚀 Deploy
         shell: |
           make deploy{{ include "delivery_target" $delivery }} \
-            {{ `${{ inputs.deploy_ref != '' && format('REF={0}', inputs.deploy_ref) || '' }}` }}
+            {{ `${{ inputs.deploy_ref != '' && format('REF={0}', inputs.deploy_ref) || '' }}` }} \
+            {{ `${{ inputs.env }}` }}
 
     - name: Update {{ $delivery_name }} GitHub Deployment status (success)
       if: >


### PR DESCRIPTION
This is the most straightforward approach for now, as discussed lately:

```yaml
      - name: 'Release'
        uses: ./.manala/github/deliveries
        with:
          # […]
          tier: ${{ github.event.inputs.tier }}
          env: |
            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
            COMPOSER_AUTH=${{ secrets.COMPOSER_AUTH }}
```

To use different value per app / tier, simply rely on Github's conditional steps feature: 

```yaml
      - name: 'Release staging'
        uses: ./.manala/github/deliveries
        if: ${{ github.event.inputs.tier == 'staging' }}
        with:
          # […]
          tier: staging
          env: |
            SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }} \
            COMPOSER_AUTH=${{ secrets.STAGING_COMPOSER_AUTH }}

      - name: 'Release production'
        uses: ./.manala/github/deliveries
        if: ${{ github.event.inputs.tier == 'production' }}
        with:
          # […]
          tier: production
          env: |
            SENTRY_AUTH_TOKEN=${{ secrets.PRODUCTION_SENTRY_AUTH_TOKEN }} \
            COMPOSER_AUTH=${{ secrets.PRODUCTION_COMPOSER_AUTH }}
```

### Considerations

I chose to scope this to deliveries action only, since anyone is already able to forward env vars in the same way using the `./.manala/github/system` action and `shell` key:

```yaml
      - name: 'Install dependencies & setup project'
        uses: ./.manala/github/system
        timeout-minutes: 3
        with:
          app: back
          shell: COMPOSER_AUTH=${{ secrets.COMPOSER_AUTH }} make install.composer@integration
```

_Also, handling the `env` key this way in `./.manala/github/system` would be misleading since it'll only forward env vars to the first command line._ 


### Alternatives

As discussed, we might consider some other alternatives, such as a `./.manala/github/env` action, writing to a `.env` file known by Manala, which would be forwarded to our Docker app service using [the `env_file` configuration option](https://docs.docker.com/compose/environment-variables/#the-env_file-configuration-option), before the setup action and the container is up.