### PR TITLE
[elao.app.docker] Provide a way to forwards secrets as env vars during release/deploy (alternative using .env & env_file)

### DIFF
--- a/elao.app.docker/.manala/docker/compose/env.yaml
+++ b/elao.app.docker/.manala/docker/compose/env.yaml
@@ -1,0 +1,11 @@
+name: app
+
+services:
+
+    #######
+    # App #
+    #######
+
+    app:
+        env_file:
+            - .env

--- a/elao.app.docker/.manala/docker/compose/env.yaml
+++ b/elao.app.docker/.manala/docker/compose/env.yaml
@@ -8,4 +8,4 @@ services:
 
     app:
         env_file:
-            - .env
+            - ${MANALA_ENV_FILE:-.env.manala}

--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -131,7 +131,8 @@ jobs:
 In case you need to expose secrets as env vars, for instance to provide an auth token during the release process,
 you can use the `with.env` key to provide a string of env vars to be forwarded, as shown above.
 
-Use Github [steps conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif) in order to expose different secrets depending on the app / tier:
+Use Github [steps conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif)
+and the `./.manala/github/env` action in order to expose different secrets depending on the app / tier:
 
 ```yaml
 jobs:
@@ -139,30 +140,26 @@ jobs:
     # […]
     steps:
       # […]
-      - name: Staging Release
-        uses: ./.manala/github/deliveries
+      - name: Configure staging secrets
+        uses: ./.manala/github/env
         if: {{ `${{ github.event.inputs.tier == 'staging' }}` }}
         with:
-          secrets: {{ `${{ toJSON(secrets) }}` }}
           env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }}` }}
-          {{- if $apps }}
-          app: {{ `${{ github.event.inputs.app }}` }}
-          {{- end }}
-          tier: staging
-          ref: {{ `${{ github.event.inputs.ref }}` }}
-          release: true
-          deploy: {{ `${{ github.event.inputs.deploy }}` }}
 
-      - name: Production Release
-        uses: ./.manala/github/deliveries
+      - name: Configure production secrets
+        uses: ./.manala/github/env
         if: {{ `${{ github.event.inputs.tier == 'production' }}` }}
         with:
+          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.production_SENTRY_AUTH_TOKEN }}` }}
+
+      - name: Release
+        uses: ./.manala/github/deliveries
+        with:
           secrets: {{ `${{ toJSON(secrets) }}` }}
-          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.PRODUCTION_SENTRY_AUTH_TOKEN }}` }}
           {{- if $apps }}
           app: {{ `${{ github.event.inputs.app }}` }}
           {{- end }}
-          tier: production
+          tier: {{ `${{ github.event.inputs.tier }}` }}
           ref: {{ `${{ github.event.inputs.ref }}` }}
           release: true
           deploy: {{ `${{ github.event.inputs.deploy }}` }}

--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -74,6 +74,9 @@ jobs:
           ref: {{ `${{ github.event.inputs.ref }}` }}
           release: true
           deploy: {{ `${{ github.event.inputs.deploy }}` }}
+          #env: |
+          #  {{ `SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \` }}
+          #  {{ `COMPOSER_AUTH=${{ secrets.COMPOSER_AUTH }}` }}
 ```
 
 `.github/workflows/deploy.yaml`:
@@ -121,6 +124,48 @@ jobs:
           release: false
           deploy: true
           deploy_ref: {{ `${{ github.event.inputs.ref }}` }}
+```
+
+### Exposing secrets
+
+In case you need to expose secrets as env vars, for instance to provide an auth token during the release process,
+you can use the `with.env` key to provide a string of env vars to be forwarded, as shown above.
+
+Use Github [steps conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif) in order to expose different secrets depending on the app / tier:
+
+```yaml
+jobs:
+  release:
+    # […]
+    steps:
+      # […]
+      - name: Staging Release
+        uses: ./.manala/github/deliveries
+        if: {{ `${{ github.event.inputs.tier == 'staging' }}` }}
+        with:
+          secrets: {{ `${{ toJSON(secrets) }}` }}
+          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }}` }}
+          {{- if $apps }}
+          app: {{ `${{ github.event.inputs.app }}` }}
+          {{- end }}
+          tier: staging
+          ref: {{ `${{ github.event.inputs.ref }}` }}
+          release: true
+          deploy: {{ `${{ github.event.inputs.deploy }}` }}
+
+      - name: Production Release
+        uses: ./.manala/github/deliveries
+        if: {{ `${{ github.event.inputs.tier == 'production' }}` }}
+        with:
+          secrets: {{ `${{ toJSON(secrets) }}` }}
+          env: {{ `SENTRY_AUTH_TOKEN=${{ secrets.PRODUCTION_SENTRY_AUTH_TOKEN }}` }}
+          {{- if $apps }}
+          app: {{ `${{ github.event.inputs.app }}` }}
+          {{- end }}
+          tier: production
+          ref: {{ `${{ github.event.inputs.ref }}` }}
+          release: true
+          deploy: {{ `${{ github.event.inputs.deploy }}` }}
 ```
 
 {{- end }}

--- a/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
@@ -26,6 +26,10 @@ inputs:
   deploy_ref:
     description: Deploy Ref
     required: false
+  env:
+    description: Env vars as a single string
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -55,6 +59,7 @@ runs:
       uses: ./.manala/github/system
       with:
         setup: true
+        env: {{ `${{ inputs.env }}` }}
         {{- if hasKey $delivery "github_ssh_key_secret" }}
         ssh_key: {{ printf "${{ fromJSON(inputs.secrets).%s }}" $delivery.github_ssh_key_secret }}
         {{- end }}

--- a/elao.app.docker/.manala/github/env/action.yaml
+++ b/elao.app.docker/.manala/github/env/action.yaml
@@ -1,0 +1,26 @@
+name: Env
+description: Env
+author: Elao
+
+inputs:
+  env:
+    description: Env vars as a single string
+
+runs:
+  using: composite
+  steps:
+
+    #######
+    # Env #
+    #######
+
+    - name: Configure env vars
+      shell: bash
+      run: |
+        cat >> ${RUNNER_TEMP}/.env <<EOF
+        ${{ inputs.env }}
+        EOF
+
+    - name: Save dotenv path
+      shell: bash
+      run: echo "MANALA_ENV_FILE=${RUNNER_TEMP}/.env" >> $GITHUB_ENV

--- a/elao.app.docker/.manala/github/system/action.yaml
+++ b/elao.app.docker/.manala/github/system/action.yaml
@@ -8,6 +8,10 @@ inputs:
     default: 'false'
     type: boolean
     required: false
+  env:
+      description: Env vars as a single string. Must be used before/during setup.
+      required: false
+      default: ''
   setup_group:
     description: Shell group
     required: false
@@ -25,10 +29,6 @@ inputs:
   app:
     description: App
     required: false
-  env:
-    description: Env vars as a single string
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -38,10 +38,12 @@ runs:
     # Env #
     #######
 
+    # Configure the env vars from the env input provided during setup if any.
     - name: Configure env vars
       if: inputs.setup != 'false' && inputs.env != ''
-      shell: bash
-      run: echo "${{ inputs.env }}" >> .manala/docker/.env
+      uses: ./.manala/github/env
+      with:
+        env: ${{ inputs.env }}
 
     #########
     # Setup #
@@ -99,7 +101,7 @@ runs:
             --file ./.manala/docker/compose/integration.yaml \
             --file ./.manala/docker/compose/cache.yaml \
             ${{ inputs.ssh_key != '' && '--file ./.manala/docker/compose/ssh-key.yaml' || '' }} \
-            ${{ inputs.env != '' && '--file ./.manala/docker/compose/env.yaml' || '' }} \
+            ${{ env.MANALA_ENV_FILE && '--file ./.manala/docker/compose/env.yaml' || '' }} \
             up \
             --detach
         echo "::endgroup::"

--- a/elao.app.docker/.manala/github/system/action.yaml
+++ b/elao.app.docker/.manala/github/system/action.yaml
@@ -25,10 +25,23 @@ inputs:
   app:
     description: App
     required: false
+  env:
+    description: Env vars as a single string
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
+
+    #######
+    # Env #
+    #######
+
+    - name: Configure env vars
+      if: inputs.setup != 'false' && inputs.env != ''
+      shell: bash
+      run: echo "${{ inputs.env }}" >> .manala/docker/.env
 
     #########
     # Setup #
@@ -86,6 +99,7 @@ runs:
             --file ./.manala/docker/compose/integration.yaml \
             --file ./.manala/docker/compose/cache.yaml \
             ${{ inputs.ssh_key != '' && '--file ./.manala/docker/compose/ssh-key.yaml' || '' }} \
+            ${{ inputs.env != '' && '--file ./.manala/docker/compose/env.yaml' || '' }} \
             up \
             --detach
         echo "::endgroup::"


### PR DESCRIPTION
Alternative to #243 

It has the advantage to make it available using the `./.manala/github/system` action directly and for the whole shell.

Also removes the need for the extra `\` for multiline strings:

```diff
      - name: 'Release'
        uses: ./.manala/github/deliveries
        with:
          # […]
          tier: ${{ github.event.inputs.tier }}
          env: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
            COMPOSER_AUTH=${{ secrets.COMPOSER_AUTH }}
```

Also, as shown below, it allows to expose a new `./.manala/github/system` action to pre-configure secrets for different app / tier / whatever.

### Configuring different secrets per app / tier


```yml

jobs:
  release:
    # […]
    steps:
      # […]
      - name: Configure staging secrets
        uses: ./.manala/github/env
        if: ${{ github.event.inputs.tier == 'staging' }}
        with:
          env: |
            SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }}
            COMPOSER_AUTH=${{ secrets.STAGING_COMPOSER_AUTH }}

      - name: Configure production secrets
        uses: ./.manala/github/env
        if: ${{ github.event.inputs.tier == 'production' }}
        with:
          env: |
            SENTRY_AUTH_TOKEN=${{ secrets.PRODUCTION_SENTRY_AUTH_TOKEN }}
            COMPOSER_AUTH=${{ secrets.PRODUCTION_COMPOSER_AUTH }}

      - name: Release
        uses: ./.manala/github/deliveries
        with:
          secrets: ${{ toJSON(secrets) }}
          app: ${{ github.event.inputs.app }}
          tier: ${{ github.event.inputs.tier }}
          ref: ${{ github.event.inputs.ref }}
          release: true
          deploy: ${{ github.event.inputs.deploy }}
```

