### PR TITLE
[Elao - App - Docker] Fixup the release msg commit reference

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
@@ -20,5 +20,5 @@ release_remove: []
 release_author: ~
 
 # Regex
-release_git_url_regex: '^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repository>.+).git$'
+release_git_url_regex: '^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repository>.+)(?P<extension>.git)?$'
 release_email_regex: '^(?P<name>.*) <(?P<email>.*)>$'


### PR DESCRIPTION
Fixes #77

On Github CI, `git config --get remote.origin.url` outputs: https://github.com/org/repo [(without the .git)](
https://github.com/actions/checkout/issues/408#issuecomment-1007818466), which cause the regex to fail and the release commit msg to have a double `https://`:

![SCR-20220908-lvp](https://user-images.githubusercontent.com/2211145/189138372-58200471-7410-4ab7-8768-4ff6e9aca6f7.png)

The issue does not happen locally, since it has the `.git` ext, so the `regex_replace` does its job.

Github CI debug with this fix:

![SCR-20220908-lxk](https://user-images.githubusercontent.com/2211145/189138968-0d3b9052-ce9d-4f22-a9db-23afb8c7fc37.png)
