### PR TITLE
[Elao - App - Docker] Add workflow run-name for releases to show the target (app+tier)

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -26,6 +26,7 @@
 
 ```yaml
 name: Release
+run-name: {{ `${{ format('Release{0} of {1} on {2}', github.event.inputs.deploy == 'true' && ' & Deploy' || '', github.event.inputs.app, github.event.inputs.tier) }}` }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
https://github.blog/changelog/2022-09-26-github-actions-dynamic-names-for-workflow-runs/
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#name

| Après | Avant | Bloopers 😬 |
| - | - | - |
|![SCR-20220927-cq6](https://user-images.githubusercontent.com/2211145/192458185-a66186b4-0a68-4681-97e8-eb2d35d28f4c.png)|![SCR-20220927-cqc](https://user-images.githubusercontent.com/2211145/192458188-1d13d516-97b0-4afe-bd52-1badeb71fa99.png)|![SCR-20220927-cqo](https://user-images.githubusercontent.com/2211145/192458192-fddaaa19-22e9-4345-b857-15c2d60bd817.png)|