### PR TITLE
[Elao - App - Docker] Fix release markup commit URL

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/defaults/main.yml
@@ -24,5 +24,5 @@ release_remove: []
 release_author: ~
 
 # Regex
-release_git_url_regex: '^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repository>.+)(?P<extension>.git)?$'
+release_git_url_regex: '^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repository>.+?)(?P<extension>.git)?$'
 release_email_regex: '^(?P<name>.*) <(?P<email>.*)>$'


### PR DESCRIPTION
By using lazy `repository` capturing group:

![SCR-20220928-nz7](https://user-images.githubusercontent.com/2211145/192817837-bd8b59ce-c9a9-4b0c-bbe3-02ed99311cce.png)

https://regex101.com/r/gV6FVc/1