### PR TITLE
[Elao - App - Docker] Attempt to fix concurrent release markup issues

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/tasks/markup.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/tasks/markup.yml
@@ -8,6 +8,13 @@
     update: false
   register: __release_repo_git_info
 
+# Pull the original repository changes to prevent concurrent releases issues
+- name: git > Pull original repository
+  ansible.builtin.shell: git pull --rebase origin
+  args:
+    chdir: "{{ release_git_dir }}"
+  tags: log_failed
+
 - name: git > Commit to original repository
   ansible.builtin.shell: |
     git {{


### PR DESCRIPTION
Whenever two jobs are releasing at the same time (ex: api & front apps), one might be behind the other one, and its markup commit would be rejected because the tree is not up-to-date.

Simple solution: let's pull before commit and push.