### PR TITLE
[Elao - App - Docker] Edit template to respect healthchecking at containers start

### DIFF
--- a/elao.app.docker/.manala/Makefile.tmpl
+++ b/elao.app.docker/.manala/Makefile.tmpl
@@ -37,7 +37,6 @@ HELP += $(call help,setup,                 Setup environment (DEBUG))
 setup:
 	$(_docker_compose) up \
 		--build \
-		--detach \
 		--wait
 	$(setup)
 	$(MAKE) help

--- a/elao.app.docker/.manala/github/system/action.yaml
+++ b/elao.app.docker/.manala/github/system/action.yaml
@@ -103,6 +103,7 @@ runs:
             ${{ inputs.ssh_key != '' && '--file ./.manala/docker/compose/ssh-key.yaml' || '' }} \
             ${{ env.MANALA_ENV_FILE && '--file ./.manala/docker/compose/env.yaml' || '' }} \
             up \
+            --wait
         echo "::endgroup::"
 
     #########

--- a/elao.app.docker/.manala/github/system/action.yaml
+++ b/elao.app.docker/.manala/github/system/action.yaml
@@ -103,7 +103,6 @@ runs:
             ${{ inputs.ssh_key != '' && '--file ./.manala/docker/compose/ssh-key.yaml' || '' }} \
             ${{ env.MANALA_ENV_FILE && '--file ./.manala/docker/compose/env.yaml' || '' }} \
             up \
-            --detach
         echo "::endgroup::"
 
     #########


### PR DESCRIPTION
We had an error at starting in a project with ES : container available while the service not yet.
We fix it by removing --detach command in template file for this recipe.