### PR TITLE
[Elao - App - Docker] Improve healthchek for Elasticsearch

### DIFF
--- a/elao.app.docker/.manala/Jenkinsfile.tmpl
+++ b/elao.app.docker/.manala/Jenkinsfile.tmpl
@@ -318,7 +318,7 @@ podTemplate(
             // - Delete indexes
             container('elasticsearch') {
                 sh label: 'Setup Elasticsearch service', script: '''
-                    while ! curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cat/health?h=st; do
+                    while ! curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow; do
                         sleep 0.25
                     done
                     curl --silent --request DELETE http://127.0.0.1:9200/_all

--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -69,7 +69,7 @@ services:
             exec docker-entrypoint.sh"
         network_mode: service:app
         healthcheck:
-            test: curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cat/health?h=st
+            test: curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow
             interval: 30s
             timeout: 30s
             retries: 3

--- a/elao.app.docker/.manala/jenkins/Jenkinsfile.tmpl
+++ b/elao.app.docker/.manala/jenkins/Jenkinsfile.tmpl
@@ -318,7 +318,7 @@ podTemplate(
             // - Delete indexes
             container('elasticsearch') {
                 sh label: 'Setup Elasticsearch service', script: '''
-                    while ! curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cat/health?h=st; do
+                    while ! curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow; do
                         sleep 0.25
                     done
                     curl --silent --request DELETE http://127.0.0.1:9200/_all


### PR DESCRIPTION
Use `wait_for_status` param to handle ElasticSearch healthcheck and fix unavailable service bugs at start