### PR TITLE
[Elao- App - Docker] Add node_modules cache to suggested mutagen ignore

### DIFF
--- a/elao.app.docker/.manala.yaml.tmpl
+++ b/elao.app.docker/.manala.yaml.tmpl
@@ -113,6 +113,8 @@ system:
     #             paths:
     #                 # Webpack build files
     #                 - /public/build/
+    #                 # Node modules cache (Babel, ...)
+    #                 - /node_modules/.cache
     #                 # Symfony log & cache files
     #                 - /var/cache
     #                 - /var/log

--- a/elao.app.docker/README.md
+++ b/elao.app.docker/README.md
@@ -298,6 +298,8 @@ system:
                 paths:
                     # Webpack build files
                     - /public/build/
+                    # Node modules cache (Babel, ...)
+                    - /node_modules/.cache
                     # Symfony log & cache files
                     - /var/cache
                     - /var/log


### PR DESCRIPTION
It seems webpack (babel to be precise) put some crap in the `/node_modules/.cache/` directory during asset build process. This cache can be updated at each build/watch with a significant amount of files that could impact mutagen performance.