### PR TITLE
[Elao - App - Docker] Update README about delivery ref

### DIFF
--- a/elao.app.docker/README.md
+++ b/elao.app.docker/README.md
@@ -543,9 +543,9 @@ Here is an example of a production/staging deliveries configuration in `.manala.
 deliveries:
 
   - &delivery
-    #app: api # Optional
+    #app: api # Optional. Useful for multi-app projects (api, front, backend, etc.)
     tier: production
-    #ref: staging # Default to master
+    #ref: master # Git reference to deliver (can be a branch or a commit). Default value is "master"
     # Release
     release_repo: git@git.example.com:<vendor>/<app>-release.git
     #release_ref: master # Based on app/tier by default
@@ -609,6 +609,7 @@ deliveries:
 
   - << : *delivery
     tier: staging
+    ref: staging
     release_tasks:
       - shell: make install@staging
       - shell: make build@staging


### PR DESCRIPTION
Mise à jour de la documentation de la recipe `Elao app Docker` - Rubrique `deliveries` : 

- ajout d'un commentaire précisant le rôle de la variable `ref` (le terme `ref` me semblait trop générique et je me demandais pourquoi on ne mettait pas plutôt `branch` qui a l'avantage d'être plus clair)

- dans l'exemple de config d'une delivery, je précise `ref: staging` pour la partie `staging` ... ça me semble une meilleure variable par défaut pour les déploiements en staging que la branche `master` ...