### PR TITLE
[Elao - App - Docker] Deploy workflow after release separately, using GH CLI

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -22,6 +22,8 @@
 {{- $tiers = (append $tiers $delivery.tier) | uniq -}}
 {{- end }}
 
+### Release Workflow
+
 `.github/workflows/release.yaml`:
 
 ```yaml
@@ -50,7 +52,7 @@ on:
       deploy:
         description: Follow with a deployment if release succeeded
         type: boolean
-        default: 'false'
+        default: false
         required: false
 
 concurrency:
@@ -74,16 +76,27 @@ jobs:
           tier: {{ `${{ github.event.inputs.tier }}` }}
           ref: {{ `${{ github.event.inputs.ref }}` }}
           release: true
-          deploy: {{ `${{ github.event.inputs.deploy }}` }}
           #env: |
           #  {{ `SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}` }}
           #  {{ `COMPOSER_AUTH='{ "github-oauth": { "github.com": "${{ secrets.COMPOSER_AUTH_TOKEN }}" } }'` }}
+
+      - name: 'Trigger deployment workflow'
+        if: success() && github.event.inputs.deploy == 'true'
+        env:
+          GH_TOKEN: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+        run: |
+          gh workflow run deploy \
+              --field app={{ `${{ github.event.inputs.app }}` }} \
+              --field tier={{ `${{ github.event.inputs.tier }}` }}
 ```
+
+### Deploy Workflow
 
 `.github/workflows/deploy.yaml`:
 
 ```yaml
 name: Deploy
+run-name: {{ `${{ format('Deploy {0} on {1}', github.event.inputs.app, github.event.inputs.tier) }}` }}
 
 on:
   workflow_dispatch:
@@ -126,6 +139,7 @@ jobs:
           deploy: true
           deploy_ref: {{ `${{ github.event.inputs.ref }}` }}
 ```
+
 ## Exposing secrets
 
 Read more about [exposing secrets to Manala actions](../env/README.md).


### PR DESCRIPTION
Thanks to https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows 🎉 !

Previously, the sampled release workflow was performing the deploy task, if checked, **in the same workflow**, which is really not awesome, since you don't clearly see it and have to dig **inside the release workflow** run logs.

To circumvent this, I always used a different method to **trigger the deployment workflow from the release workflow**, using the Github API and a Github OAuth app for authentication:

```yaml
     # inside the release workflows, after succeeded:
     # […]

      - name: 'Get Workflows Knight app token'
        id: get_app_token
        if: success() && github.event.inputs.deploy == 'true'
        uses: machine-learning-apps/actions-app-token@master
        with:
          APP_PEM: ${{ secrets.WORKFLOWS_KNIGHT_APP_PEM_BASE_64 }}
          APP_ID: ${{ secrets.WORKFLOWS_KNIGHT_APP_ID }}

      - name: 'Trigger deployment workflow'
        uses: benc-uk/workflow-dispatch@v1
        if: success() && github.event.inputs.deploy == 'true'
        with:
          workflow: Deploy
          token: ${{ steps.get_app_token.outputs.app_token }}
          inputs: |
            {
              "tier": "${{ github.event.inputs.tier }}",
              "app": "${{ github.event.inputs.app }}"
            }
```

With this, our Github OAuth app "Workflows Knight" was triggering the deploy workflow after the release:

![SCR-20221013-n54](https://user-images.githubusercontent.com/2211145/195627659-4fe45769-0be9-44c7-a12f-d8d8141d7132.png)

But…

…we don't need the Github OAuth app for this anymore, since we can use GH ClI with the `GITHUB_TOKEN` !

```yaml
      - name: 'Trigger deployment workflow'
        if: success() && github.event.inputs.deploy == 'true'
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh workflow run deploy \
              --field app=${{ github.event.inputs.app }} \
              --field tier=${{ github.event.inputs.tier }}
```

![SCR-20221013-n4p](https://user-images.githubusercontent.com/2211145/195627627-f02f8ca3-aa23-4b50-b6e3-0a0317375739.png)

**So, let's never trigger the deploy task inside the release workflow anymore: trigger the deploy workflow separately with this instead.**