### PR TITLE
[Elao - App - Docker] Add a Github Workflow to reset stagings

### DIFF
--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -2,7 +2,7 @@
 
 {{- if not .Vars.deliveries }}
 
-¯\_(ツ)_/¯ Because it works on my machine...
+¯\_(ツ)_/¯ No delivery configured...
 
 {{- else }}
 

--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -2,7 +2,7 @@
 
 {{- if not .Vars.deliveries }}
 
-¯\_(ツ)_/¯ No delivery configured...
+¯\_(ツ)_/¯ No delivery configured…
 
 {{- else }}
 
@@ -33,20 +33,38 @@
 {{- end }}
 {{- $tiers = without $tiers "production" -}}
 
+{{- if eq (len $tiers) 0 }}
+
+¯\_(ツ)_/¯ No staging…
+
+{{- else }}
+
+{{- $tierRef := $tiers | first -}}
+{{- $singleTier := eq (len $tiers) 1 -}}
+{{- if not $singleTier }}
+{{- $tierRef = `${{ matrix.tier }}` -}}
+{{- end }}
+
 `.github/workflows/reset-stagings.yaml`:
 
 ```yaml
 name: Reset stagings
+{{- if $singleTier }}
+run-name: 'Reset {{ $tierRef }} branch'
+{{- else }}
 run-name: {{ `${{ format('Reset {0} branche(s)', github.event.inputs.tiers == 'all' && 'all stagings' || github.event.inputs.tiers) }}` }}
+{{- end }}
 
 on:
   workflow_dispatch:
     inputs:
+      {{- if not $singleTier }}
       tiers:
         description: Tier branches to reset
         type: choice
         options: [all, {{ $tiers | join ", " }}]
         required: true
+      {{- end }}
       ref:
         description: Git reference.
         default: {{ $mainBranch }}
@@ -63,10 +81,15 @@ on:
         required: false
 
 concurrency:
+  {{- if $singleTier }}
+  group: {{ `${{ github.workflow }}-${{ github.ref }}` }}
+  {{- else }}
   group: {{ `${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.tiers }}` }}
+  {{- end }}
   cancel-in-progress: true
 
 jobs:
+  {{- if not $singleTier }}
   matrix:
     name: 'Compute matrix'
     runs-on: ubuntu-latest
@@ -81,59 +104,66 @@ jobs:
           echo $matrix
           echo $matrix | jq .
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+  {{- end }}
 
   reset:
+    name: 'Reset {{ $tierRef }} branch'
+    {{- if not $singleTier }}
     needs: matrix
-    name: 'Reset {{ `${{ matrix.tier }}` }} branch'
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions
       matrix: {{ `${{ fromJson(needs.matrix.outputs.matrix) }}` }}
+    {{- end }}
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: {{ `${{ secrets.GITHUB_TOKEN }}` }}
 
     steps:
-      - name: {{ `'Reset hard ${{ matrix.tier }} branch on ${{ github.event.inputs.ref }}'` }}
+      - name: {{ `'Reset hard $tierRef branch on ${{ github.event.inputs.ref }}'` | replace "$tierRef" $tierRef }}
         uses: nicksnell/action-reset-repo@master
         with:
           github_token: {{ `${{ secrets.GITHUB_TOKEN }}` }}
           base_branch: {{ `${{ github.event.inputs.ref }}` }}
-          reset_branch: {{ `${{ matrix.tier }}` }}
+          reset_branch: {{ $tierRef }}
 
-      - name: 'Find PRs with label {{ `${{ matrix.tier }}` }}'
+      - name: 'Find PRs with label {{ $tierRef }}'
         id: find-prs
         run: |
-          prs=$(gh pr list --label '{{ `${{ matrix.tier }}` }}' --json=number --state open | jq -cr '.|map(.number)')
+          prs=$(gh pr list --label '{{ $tierRef }}' --json=number --state open | jq -cr '.|map(.number)')
           echo $prs
           echo $prs | jq .
           echo "prs=$prs" >> $GITHUB_OUTPUT
 
-      - name: 'Labelize opened PRs with label {{ `${{ matrix.tier }}` }}'
+      - name: 'Labelize opened PRs with label {{ $tierRef }}'
         run: |
           echo {{ `${{ steps.find-prs.outputs.prs }}` }} | jq -c '.[]' | while read pr; do
             gh pr view $pr --json=number,title || true
-            gh pr edit $pr --remove-label {{ `${{ matrix.tier }}` }} || true
-            gh pr edit $pr --add-label {{ `${{ matrix.tier }}` }}-reset || true
+            gh pr edit $pr --remove-label {{ $tierRef }} || true
+            gh pr edit $pr --add-label {{ $tierRef }}-reset || true
           done
 
-      - name: 'Notify opened PRs with label {{ `${{ matrix.tier }}` }}'
+      - name: 'Notify opened PRs with label {{ $tierRef}}'
         if: success() && github.event.inputs.comment == 'true'
         run: |
           echo {{ `${{ steps.find-prs.outputs.prs }}` }} | jq -c '.[]' | while read pr; do
             gh pr view $pr --json=number,title
-            {{ `gh pr comment $pr --body "> **Warning** la branche ^b^${{ matrix.tier }}^b^ a été reset. Cette PR doit à nouveau être mergée sur ^b^${{ matrix.tier }}^b^"`| replace "^b^" "\\`" }}
+            {{ `gh pr comment $pr --body "> **Warning** la branche ^b^$tierRef^b^ a été reset. Cette PR doit à nouveau être mergée sur ^b^$tierRef^b^"`| replace "^b^" "\\`" | replace "$tierRef" $tierRef }}
           done
 
   deploy:
+    name: 'Re-release & deploy {{ $tierRef }} branch'
     if: success() && github.event.inputs.deploy == 'true'
+    {{- if not $singleTier }}
     needs: [matrix, reset]
-    name: 'Re-release & deploy {{ `${{ matrix.tier }}` }} branch'
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions
       matrix: {{ `${{ fromJson(needs.matrix.outputs.matrix) }}` }}
+    {{- else }}
+    needs: reset
+    {{- end }}
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: {{ `${{ secrets.GITHUB_TOKEN }}` }}
 
@@ -141,12 +171,13 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
 
-      - name: 'Trigger release workflow for back@{{ `${{ matrix.tier }}` }}'
+      - name: 'Trigger release workflow for back@{{ $tierRef }}'
         run: |
           gh workflow run release \
               --field deploy=true \
               --field app=back \
-              --field tier={{ `${{ matrix.tier }}` }}
+              --field tier={{ $tierRef }}
 ```
 
+{{- end }}
 {{- end }}

--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -45,7 +45,15 @@
 {{- $tierRef = `${{ matrix.tier }}` -}}
 {{- end }}
 
-`.github/workflows/reset-stagings.yaml`:
+In order to properly detect and notify PRs already merged in a staging branch,
+you might want to add the following labels to your GitHub repository:
+
+{{ range $tier := $tiers -}}
+* `{{ $tier }}`
+* `{{ $tier }}-reset`
+{{- end }}
+
+Create the `.github/workflows/reset-stagings.yaml` workflow file:
 
 ```yaml
 name: Reset stagings

--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -178,13 +178,22 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
+      {{- range $app := $apps }}
 
-      - name: 'Trigger release workflow for back@{{ $tierRef }}'
+      - name: 'Trigger release workflow for {{ $app }}@{{ $tierRef }}'
         run: |
           gh workflow run release \
               --field deploy=true \
-              --field app=back \
+              --field app={{ $app }} \
               --field tier={{ $tierRef }}
+      {{- else }}
+
+      - name: 'Trigger release workflow for {{ $tierRef }}'
+        run: |
+          gh workflow run release \
+              --field deploy=true \
+              --field tier={{ $tierRef }}
+      {{- end }}
 ```
 
 {{- end }}

--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -1,0 +1,152 @@
+# Reset stagings
+
+{{- if not .Vars.deliveries }}
+
+¯\_(ツ)_/¯ Because it works on my machine...
+
+{{- else }}
+
+## Usage
+
+{{- /* Guess apps */ -}}
+{{- $apps := list -}}
+{{- range $delivery := .Vars.deliveries -}}
+  {{- if hasKey $delivery "app" -}}
+    {{- $apps = (append $apps $delivery.app) | uniq -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Guess main branch */ -}}
+{{- $mainBranch := "master" -}}
+{{- range $delivery := .Vars.deliveries -}}
+  {{- if hasKey $delivery "ref" -}}
+    {{- if eq $delivery.tier "production" -}}
+      {{- $mainBranch = $delivery.ref -}}
+    {{- end -}}
+  {{- end -}}
+{{- end }}
+
+{{- /* Guess tiers */ -}}
+{{- $tiers := list -}}
+{{- range $delivery := .Vars.deliveries -}}
+  {{- $tiers = (append $tiers $delivery.tier) | uniq -}}
+{{- end }}
+{{- $tiers = without $tiers "production" -}}
+
+`.github/workflows/reset-stagings.yaml`:
+
+```yaml
+name: Reset stagings
+run-name: {{ `${{ format('Reset {0} branche(s)', github.event.inputs.tiers == 'all' && 'all stagings' || github.event.inputs.tiers) }}` }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tiers:
+        description: Tier branches to reset
+        type: choice
+        options: [all, {{ $tiers | join ", " }}]
+        required: true
+      ref:
+        description: Git reference.
+        default: {{ $mainBranch }}
+        required: true
+      comment:
+        description: Add a comment to notify opened PRs
+        type: boolean
+        default: true
+        required: false
+      deploy:
+        description: Re-release and deploy the branches with the new code
+        type: boolean
+        default: false
+        required: false
+
+concurrency:
+  group: {{ `${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.tiers }}` }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    name: 'Compute matrix'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: {{ `${{ steps.set-matrix.outputs.matrix }}` }}
+
+    steps:
+      - name: 'Compute matrix'
+        id: set-matrix
+        run: |
+          matrix='{{ `${{ github.event.inputs.tiers == 'all' && '{ "tier": ^tiers^ }' || format('{{ "tier"{0} ["{1}"] }}', ':', github.event.inputs.tiers) }}` | replace "^tiers^" ($tiers | toJson) }}'
+          echo $matrix
+          echo $matrix | jq .
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  reset:
+    needs: matrix
+    name: 'Reset {{ `${{ matrix.tier }}` }} branch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions
+      matrix: {{ `${{ fromJson(needs.matrix.outputs.matrix) }}` }}
+    env:
+      GH_TOKEN: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+
+    steps:
+      - name: {{ `'Reset hard ${{ matrix.tier }} branch on ${{ github.event.inputs.ref }}'` }}
+        uses: nicksnell/action-reset-repo@master
+        with:
+          github_token: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+          base_branch: {{ `${{ github.event.inputs.ref }}` }}
+          reset_branch: {{ `${{ matrix.tier }}` }}
+
+      - name: 'Find PRs with label {{ `${{ matrix.tier }}` }}'
+        id: find-prs
+        run: |
+          prs=$(gh pr list --label '{{ `${{ matrix.tier }}` }}' --json=number --state open | jq -cr '.|map(.number)')
+          echo $prs
+          echo $prs | jq .
+          echo "prs=$prs" >> $GITHUB_OUTPUT
+
+      - name: 'Labelize opened PRs with label {{ `${{ matrix.tier }}` }}'
+        run: |
+          echo {{ `${{ steps.find-prs.outputs.prs }}` }} | jq -c '.[]' | while read pr; do
+            gh pr view $pr --json=number,title || true
+            gh pr edit $pr --remove-label {{ `${{ matrix.tier }}` }} || true
+            gh pr edit $pr --add-label {{ `${{ matrix.tier }}` }}-reset || true
+          done
+
+      - name: 'Notify opened PRs with label {{ `${{ matrix.tier }}` }}'
+        if: success() && github.event.inputs.comment == 'true'
+        run: |
+          echo {{ `${{ steps.find-prs.outputs.prs }}` }} | jq -c '.[]' | while read pr; do
+            gh pr view $pr --json=number,title
+            {{ `gh pr comment $pr --body "> **Warning** la branche ^b^${{ matrix.tier }}^b^ a été reset. Cette PR doit à nouveau être mergée sur ^b^${{ matrix.tier }}^b^"`| replace "^b^" "\\`" }}
+          done
+
+  deploy:
+    if: success() && github.event.inputs.deploy == 'true'
+    needs: [matrix, reset]
+    name: 'Re-release & deploy {{ `${{ matrix.tier }}` }} branch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions
+      matrix: {{ `${{ fromJson(needs.matrix.outputs.matrix) }}` }}
+    env:
+      GH_TOKEN: {{ `${{ secrets.GITHUB_TOKEN }}` }}
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      - name: 'Trigger release workflow for back@{{ `${{ matrix.tier }}` }}'
+        run: |
+          gh workflow run release \
+              --field deploy=true \
+              --field app=back \
+              --field tier={{ `${{ matrix.tier }}` }}
+```
+
+{{- end }}


### PR DESCRIPTION
Add a sampled workflow to reset stagings on `master` / `main` branch.

This workflow is useful whenever you want to reset the state of the stagings branches after a release to production, to start over a fresh root.

The workflow allow to:

- Choose which branches to reset (`all`, `staging`, `staging-1`, …) 
    | Trigger | All | Single |
    | - | - | - |
    |![SCR-20221004-o6v](https://user-images.githubusercontent.com/2211145/193860656-a2fd362d-1695-44af-83ba-c9de04d9b3d4.png)|![SCR-20221004-o6d](https://user-images.githubusercontent.com/2211145/193860434-8198c4dd-ddf0-4832-9a1e-de9db2106a36.png) |![SCR-20221004-pgw](https://user-images.githubusercontent.com/2211145/193872555-b9905907-68f9-4cb9-ba5c-91c1c74dab37.png)|
- Choose on which ref it should be reset (default: `master` / `main`)
- Detecting PRs with specific labels to notify them:
    - Remove the matching label. Ex: a PR with `staging-2` label ➜ remove the `staging-2` label
    - Add a `staging-1-reset` label. Ex: a PR with `staging-2` label ➜ add the `staging-2-reset` label
    - Comment the PR explaining it was removed from the branch
    ![image](https://user-images.githubusercontent.com/2211145/195646288-79dad4ce-dd00-46df-a3c2-9c30acb224f1.png)
- Choose whether to comment or not
- Choose whether to trigger a new release+deploy for each of the branches on successful reset
    | Options | Workflow run |
    | - | - |
    |![SCR-20221013-p3i](https://user-images.githubusercontent.com/2211145/195648030-dbd01854-2390-4536-9755-6d2320f5ad9b.png)|![image](https://user-images.githubusercontent.com/2211145/195648316-5081c408-bd67-4a43-bec6-89b204c0b02e.png)|

---

### TODO / Later ?

- [x] Suggest proper production branch (`master` / `main`). Could use the production delivery ref from `.manala.yaml` for this.
- [ ] Allow to configure the labels (using a yaml file ? Something like does the [labeller action](https://github.com/actions/labeler))
