### PR TITLE
[Elao - App - Docker] Fix recent make version (4.3+) env parsing with SHELL replacement

### DIFF
--- a/elao.app.docker/.manala/docker/make.mk
+++ b/elao.app.docker/.manala/docker/make.mk
@@ -71,7 +71,7 @@ endif
 
 ifndef DOCKER
 define _docker_compose
-	$(_DOCKER_COMPOSE_ENV) \
+	env $(_DOCKER_COMPOSE_ENV) \
 	$(_DOCKER_COMPOSE) \
 		$(if $(_DOCKER_COMPOSE_PROFILE),--profile $(_DOCKER_COMPOSE_PROFILE)) \
 		$(foreach FILE, $(_DOCKER_COMPOSE_FILE), \


### PR DESCRIPTION
This one is tricky as hell...

This is a story of enthousiastics developpers who mainly works on MacOS. On MacOS, don't ask me why, the `make` version is stick on stone-age:
```shell
$ make --version
GNU Make 3.81
...

This program built for i386-apple-darwin11.3.0
```
(note the `i386-apple-darwin11.3.0`)

Now, some young hipsters have decided to switch to Linux, especially on ubuntu (22.04) where make version is a bit more decent (4.3)
Nice !
Except for this sneaky bug: https://savannah.gnu.org/bugs/?61309

Long story short, we use shell replacement in makefiles to allow some targets to be played either inside or outside the app container.
Inside the container, we use the builtin shell (`/bin/sh`) and outside the container, we pass the command to docker-compose, to be executed inside the container, by replacing the SHELL variable.
```makefile
foo: SHELL=/bin/sh
  echo I'm inside the container !

bar: SHELL=docker-compose [blablabla] /bin/sh
  echo I'm also inside the container !
```
Pretty well.
But in order for docker compose to play nice, some env variable must be passed
```makefile
bar: SHELL=DOCKER_ARG_1=something DOCKER_ARG_2=else docker-compose [blablabla] /bin/sh
  echo I'm also inside the container !
```
And boum, we run into the infamous bug (I assume that you have read the bug report just above).

One of the solution is to use the `env` command (see: https://man7.org/linux/man-pages/man1/env.1.html), and that exactly what this PR propose.

The fact is i'm a bit afraid of edge cases on other system than Linux. So let's try it with way, and see what happens :)
