### PR TITLE
[Elao - App - Docker] Fix workflow bool input default

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -56,7 +56,7 @@ on:
       deploy:
         description: Follow with a deployment if release succeeded
         type: boolean
-        default: false
+        default: 'false'
         required: false
 
 concurrency:

--- a/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
+++ b/elao.app.docker/.manala/github/reset-stagings/README.md.tmpl
@@ -80,12 +80,12 @@ on:
       comment:
         description: Add a comment to notify opened PRs
         type: boolean
-        default: true
+        default: 'true'
         required: false
       deploy:
         description: Re-release and deploy the branches with the new code
         type: boolean
-        default: false
+        default: 'false'
         required: false
 
 concurrency:


### PR DESCRIPTION
While it's working well when using the UI, using the API the default value is not used as boolean but must be provided as a string instead.

Fail during a `make trigger-release@staging`:

```shell
could not create workflow dispatch event: HTTP 422: Provided value '' for input 'deploy' not in the list of allowed values (https://api.github.com/repos/<org>/<repo>/actions/workflows/<id>/dispatches)
make: *** [trigger-release@staging] Error 1
```