### PR TITLE
[Elao - App - Docker] Use GHA deployment envs

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -47,8 +47,7 @@ on:
       {{- end }}
       tier:
         description: Tier
-        type: choice
-        options: [{{ $tiers | join ", " }}]
+        type: environment
         required: true
       ref:
         description: Git reference. Provide an explicit ref to release if it does not match your tier.
@@ -72,9 +71,10 @@ jobs:
     name: Release {{ `${{ github.event.inputs.app != '' && format('{0}@', github.event.inputs.app) || '' }}${{ github.event.inputs.tier }}` }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v3
-      - name: Release
+
+      - name: 'Release'
         uses: ./.manala/github/deliveries
         with:
           secrets: {{ `${{ toJSON(secrets) }}` }}
@@ -123,8 +123,7 @@ on:
       {{- end }}
       tier:
         description: Tier
-        type: choice
-        options: [{{ $tiers | join ", " }}]
+        type: environment
         required: true
       ref:
         description: Git reference from the release repository. Do only provide to deploy another reference than the latest available version for the tier (deploy a previous release or a specific commit).
@@ -142,11 +141,18 @@ jobs:
   deploy:
     name: Deploy {{ `${{ github.event.inputs.app != '' && format('{0}@', github.event.inputs.app) || '' }}${{ github.event.inputs.tier }}` }}
     runs-on: ubuntu-latest
+
+    environment:
+      name: {{ `${{ github.event.inputs.tier }}` }}
+      url: {{ `${{ steps.deploy.outputs.deployment_url }}` }}
+
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v3
-      - name: Deploy
+
+      - name: 'Deploy'
         uses: ./.manala/github/deliveries
+        id: deploy
         with:
           secrets: {{ `${{ toJSON(secrets) }}` }}
           app: {{ `${{ github.event.inputs.app }}` }}

--- a/elao.app.docker/.manala/github/deliveries/README.md.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/README.md.tmpl
@@ -6,6 +6,12 @@
 
 {{- else }}
 
+## Prerequisites
+
+In order for `on.inputs.tier.type = 'environment'` to work, you need to have your environments configured in your
+repository (https://github.com/<org>/<repo>/settings/environments).
+Most common environments are `production` and `staging`, but you might have multiple stages as well (`staging-1`, `staging-2`, …)
+
 ## Usage
 
 {{- /* Guess apps */ -}}

--- a/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
@@ -1,3 +1,10 @@
+{{- $apps := list -}}
+{{- range $delivery := .Vars.deliveries -}}
+{{- if hasKey $delivery "app" -}}
+{{- $apps = (append $apps $delivery.app) | uniq -}}
+{{- end -}}
+{{- end -}}
+
 name: Release
 description: Release
 author: Elao
@@ -31,6 +38,15 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  deployment_url:
+    description: The deployed app URL
+    {{- if $apps }}
+    value: {{ `${{ steps[format('deployment_url_{0}_{1}', inputs.app, inputs.tier)].outputs.deployment_url }}` }}
+    {{- else }}
+    value: {{ `${{ steps[format('deployment_url_{0}', inputs.tier)].outputs.deployment_url }}` }}
+    {{- end }}
+
 runs:
   using: composite
   steps:
@@ -38,9 +54,11 @@ runs:
     {{- range $i, $delivery := .Vars.deliveries }}
     {{- $delivery_name := $delivery.tier }}
     {{- $delivery_if := printf "inputs.tier == '%s'" $delivery.tier }}
+    {{- $delivery_id_suffix := $delivery.tier }}
     {{- if hasKey $delivery "app" }}
       {{- $delivery_name = printf "%s@%s" $delivery.app $delivery.tier }}
       {{- $delivery_if = printf "inputs.app == '%s' && inputs.tier == '%s'" $delivery.app $delivery.tier }}
+      {{- $delivery_id_suffix = printf "%s_%s" $delivery.app $delivery.tier }}
     {{- end }}
     {{- $delivery_ref := printf "${{ inputs.ref || '%s' }}" (or (get $delivery "ref") "master") }}
 
@@ -78,20 +96,13 @@ runs:
           make release{{ include "delivery_target" $delivery }} \
             AUTHOR="manala-ci-releaser <{{ `${{ github.actor }}` }}+github@manala.io>"
 
-    - name: Create {{ $delivery_name }} GitHub Deployment
+    - name: Set deployment URL for {{ $delivery_name }}
       if: >
         {{ $delivery_if }}
         && inputs.deploy != 'false'
-      uses: chrnorm/deployment-action@releases/v1
-      id: github_deployment_{{ $i }}
-      with:
-        ref: {{ $delivery_ref }}
-        description: Deploy {{ $delivery_name }}
-        token: {{ `${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}` }}
-        {{- if hasKey $delivery "deploy_url" }}
-        target_url: {{ $delivery.deploy_url }}
-        {{- end }}
-        environment: {{ $delivery.tier }}
+      id: deployment_url_{{ $delivery_id_suffix }}
+      shell: bash
+      run: echo "deployment_url={{ $delivery.deploy_url }}" >> $GITHUB_OUTPUT
 
     - name: Deploy {{ $delivery_name }}
       if: >
@@ -106,45 +117,5 @@ runs:
         shell: |
           make deploy{{ include "delivery_target" $delivery }} \
             {{ `${{ inputs.deploy_ref != '' && format('REF={0}', inputs.deploy_ref) || '' }}` }}
-
-    - name: Update {{ $delivery_name }} GitHub Deployment status (success)
-      if: >
-        {{ $delivery_if }}
-        && inputs.deploy != 'false'
-        && success() && steps.github_deployment_{{ $i }}.outcome == 'success'
-      uses: chrnorm/deployment-status@releases/v1
-      with:
-        token: {{ `${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}` }}
-        description: Deployed {{ $delivery_name }}
-        {{- if hasKey $delivery "deploy_url" }}
-        target_url: {{ $delivery.deploy_url }}
-        environment_url: {{ $delivery.deploy_url }}
-        {{- end }}
-        state: success
-        deployment_id: {{ printf "${{ steps.github_deployment_%d.outputs.deployment_id }}" $i }}
-
-    - name: Update {{ $delivery_name }} GitHub Deployment status (failure)
-      if: >
-        {{ $delivery_if }}
-        && inputs.deploy != 'false'
-        && failure() && steps.github_deployment_{{ $i }}.outcome == 'success'
-      uses: chrnorm/deployment-status@releases/v1
-      with:
-        token: {{ `${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}` }}
-        description: Failed to deploy {{ $delivery_name }}
-        state: failure
-        deployment_id: {{ printf "${{ steps.github_deployment_%d.outputs.deployment_id }}" $i }}
-
-    - name: Update {{ $delivery_name }} GitHub Deployment status (cancelled)
-      if: >
-        {{ $delivery_if }}
-        && inputs.deploy != 'false'
-        && cancelled() && steps.github_deployment_{{ $i }}.outcome == 'success'
-      uses: chrnorm/deployment-status@releases/v1
-      with:
-        token: {{ `${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}` }}
-        description: Cancelled deploy {{ $delivery_name }}
-        state: inactive
-        deployment_id: {{ printf "${{ steps.github_deployment_%d.outputs.deployment_id }}" $i }}
 
     {{- end }}

--- a/elao.app.docker/MIGRATION.2022-11.md
+++ b/elao.app.docker/MIGRATION.2022-11.md
@@ -1,0 +1,48 @@
+# Use GHA deployment environments through workflows - 2022-11 
+
+## Context
+
+Since November 2022, the **deploy** workflow sampled in `.manala/github/deliveries/README.md` handles the creation of
+GitHub deployments objects through the `jobs.environment` key instead of using the API from
+the `.manala/github/deliveries/action.yaml`.
+
+These deployments objects are used notably to trigger notifications on Slack and to expose the deployment URL in the
+GitHub UI.
+
+## Migrate
+
+Simply update the recipe in your project and adapt the `.github/workflows/deploy.yaml` workflow according to the `.manala/github/deliveries/README.md` content.
+
+The changes should look like:
+
+```diff
+         required: true
+       tier:
+         description: Tier
+-        type: choice
+-        options: [production, staging]
++        type: environment
+         required: true
+       ref:
+         description: Git reference from the release repository. Do only provide to deploy another reference than the latest available version for the tier (deploy a previous release or a specific commit).
+
+   deploy:
+     name: Deploy ${{ github.event.inputs.app != '' && format('{0}@', github.event.inputs.app) || '' }}${{ github.event.inputs.tier }}
+     runs-on: ubuntu-latest
++
++    environment:
++      name: ${{ github.event.inputs.tier }}
++      url: ${{ steps.deploy.outputs.deployment_url }}
++
+     steps:
+       - name: 'Checkout'
+         uses: actions/checkout@v3
+ 
+       - name: 'Deploy'
+         uses: ./.manala/github/deliveries
++        id: deploy
+         with:
+           secrets: ${{ toJSON(secrets) }}
+           app: ${{ github.event.inputs.app }}
+           tier: ${{ github.event.inputs.tier }}
+```


### PR DESCRIPTION
Simplifies the workflow by getting rid of the need for `chrnorm/deployment` actions to create deployment items manually using the Github API.

Instead, rely on the native Github Action environments configuration on the job (`job.<id>.environment`), which automatically creates the deployment item and handle its status according to the workflow execution status.

As a bonus, we have a better notification on Slack, mentioning the app/tier & author:
 
| Before | After |
| - | - |
|![SCR-20221028-n6w](https://user-images.githubusercontent.com/2211145/198654314-8fcfe067-022f-446f-bf55-feb0d5df77ef.png)|![SCR-20221028-n50](https://user-images.githubusercontent.com/2211145/198654321-41c9cb45-eb08-41ad-bc37-100bd9a4e998.png)|

The workflow also mentions the app URL directly:

| Pending | Done | 
| - | - |
| ![image](https://user-images.githubusercontent.com/2211145/198674309-5108c008-bde4-4725-900e-d0474a9bcf28.png)|![image](https://user-images.githubusercontent.com/2211145/198674498-62f73425-dd37-4c5f-97aa-5d0a089fa37e.png)|

Also, it allows to [require approval](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) before executing a deployment. Might be useful.

<img src="https://user-images.githubusercontent.com/2211145/198667989-efc7a9fa-b96d-4b67-86c9-afc574940ff3.png" width=350/>

---

Refs:

- https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
- https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments

---

### Next

We can also have secrets per env:

| Envs config page | Secrets config page |
| - | - |
| ![SCR-20221028-ocb](https://user-images.githubusercontent.com/2211145/198676142-e5049daa-4f35-458f-9beb-e57d6123604b.png)|![SCR-20221028-oci](https://user-images.githubusercontent.com/2211145/198676147-c400c538-e2ab-4bbe-b7bc-e8df68b33aae.png)|



So we could use this to select the SSH key to use instead of the current solution.