### PR TITLE
[Elao - App - Docker] Enhance dev-server target using HTTPS

### DIFF
--- a/elao.app.docker/.manala/docker/compose/development.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose/development.yaml.tmpl
@@ -75,7 +75,7 @@ services:
                 MANALA_PROVISION: ansible
                 MANALA_PROVISION_LIMIT: development
         ports:
-            # Usuals
+            # Usuals (Webpack dev-server, …)
             - {{ include "project_port" (list .Vars.project 88) }}:8080
             # MailHog
             - {{ include "project_port" (list .Vars.project 25) }}:8025

--- a/elao.app.docker/Makefile.dist
+++ b/elao.app.docker/Makefile.dist
@@ -80,20 +80,25 @@ serve:
 
 # ## Runs webpack dev-server with HMR enabled (PORT) using HTTPS
 # serve.assets:
+#	$(call message_success, Will be available at https://$(call project_host, 43) )
 # ifdef DOCKER
 # 	npx encore dev-server \
 # 		--host 0.0.0.0 \
-                --port 8080 \
-                --public https://$(call project_host, 88) \
-		--allowed-hosts all \
-		--server-type https \
-		--server-options-cert $(_DIR)/.manala/certificates/ssl.pem \
-		--server-options-key $(_DIR)/.manala/certificates/ssl.key \
-		--client-web-socket-url https://$(call project_host, 88)/ws
+#		--port 8080 \
+#		--public https://$(call project_host, 88) \
+#		--allowed-hosts .$(call project_host) \
+#		--server-type https \
+#		--server-options-cert $(_DIR)/.manala/certificates/ssl.pem \
+#		--server-options-key $(_DIR)/.manala/certificates/ssl.key \
+#		--client-web-socket-url https://$(call project_host, 88)/ws
 # else
 # 	npx encore dev-server \
-# 		--allowed-hosts all \
-# 		$(if $(PORT), --port $(PORT))
+#		--host $(call project_host) \
+# 		$(if $(PORT), --port $(PORT)) \
+#		--allowed-hosts .$(call project_host) \
+#		--server-type https \
+#		--server-options-cert $(_DIR)/.manala/certificates/ssl.pem \
+#		--server-options-key $(_DIR)/.manala/certificates/ssl.key
 # endif
 
 # ## Runs webpack with files watching


### PR DESCRIPTION
> **Warning**: Tested with most recent versions of Webpack & Encore. Don't assume anything regarding previous versions 😅 

Get rid of HTTPS to HTTP resource loading warnings in dev console by using HTTPS for the dev-server too.

Use more specific allowed hosts, still allowing sub-domains.