### PR TITLE
Remove warn option as it's disabled by default

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
@@ -20,8 +20,6 @@
   ansible.builtin.shell: >
     rm --recursive --force {{ release_dir }}
     && mkdir -p {{ release_dir }}
-  args:
-    warn: false
   tags: log_failed
 
 - name: git > Export repository
@@ -67,8 +65,6 @@
 - name: Remove
   ansible.builtin.shell: >
     rm --recursive --force --verbose {{ [release_dir, item]|join('/') }}
-  args:
-    warn: false
   tags: log_failed
   loop: "{{ release_remove }}"
 


### PR DESCRIPTION
The warn parameter was remove in ansible 2.14 (disabled & deprecated since ansible 2.11)

See: https://docs.ansible.com/ansible-core/2.13/collections/ansible/builtin/command_module.html#parameter-warn