### PR TITLE
[Elao - App - Docker] Optional deploy_url config entry

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/action.yaml.tmpl
@@ -102,7 +102,11 @@ runs:
         && inputs.deploy != 'false'
       id: deployment_url_{{ $delivery_id_suffix }}
       shell: bash
+      {{- if hasKey $delivery "deploy_url" }}
       run: echo "deployment_url={{ $delivery.deploy_url }}" >> $GITHUB_OUTPUT
+      {{- else }}
+      run: echo "deployment_url=" >> $GITHUB_OUTPUT
+      {{- end }}
 
     - name: Deploy {{ $delivery_name }}
       if: >


### PR DESCRIPTION
Behavior to test on a real project with latest deploy workflow up-to-date, and without the `deploy_url`