### PR TITLE
[All] Harmonize apt-get parameters

### DIFF
--- a/elao.app.docker/.manala/docker/Dockerfile.tmpl
+++ b/elao.app.docker/.manala/docker/Dockerfile.tmpl
@@ -24,13 +24,11 @@ ENV MANALA_HOST_OS=${MANALA_HOST_OS}
 ENV MANALA_HOST_PATH=${MANALA_HOST_PATH}
 
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
+    export DEBIAN_FRONTEND="noninteractive" \
     && apt-get --quiet --allow-releaseinfo-change update \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --purge --auto-remove dist-upgrade \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    && apt-get --quiet --yes --purge --auto-remove dist-upgrade \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         gnupg \
         ca-certificates \
         sudo \
@@ -74,14 +72,12 @@ ENTRYPOINT ["/entrypoint.sh"]
 FROM system AS init-sysv
 
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
+    export DEBIAN_FRONTEND="noninteractive" \
     # Work around chroot check to avoid sysvinit restart after install
     && mv /usr/bin/ischroot /usr/bin/ischroot_ \
     && ln -s /bin/true /usr/bin/ischroot \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         sysvinit-core \
     && mv /usr/bin/ischroot_ /usr/bin/ischroot \
     # Disable getty
@@ -135,12 +131,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 FROM system AS init-openrc
 
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
+    export DEBIAN_FRONTEND="noninteractive" \
     && rm -f /etc/init.d/hwclock.sh \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         openrc
 
 STOPSIGNAL SIGINT
@@ -153,11 +147,9 @@ ENTRYPOINT ["/entrypoint.sh"]
 FROM system AS init-systemd
 
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         systemd dbus \
     && systemctl set-default multi-user.target \
     && sed -i 's/#\(ForwardToConsole=\).*$/\1yes/' \
@@ -200,11 +192,9 @@ ENV LANG={{ .locales.default }}
 
 # As managed node
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         python3 \
         python3-apt
 
@@ -218,11 +208,9 @@ RUN \
     && python3.9 -m pip install --disable-pip-version-check ansible-core==${ANSIBLE_CORE_VERSION} \
 {{- else }}
 RUN \
-    # Disable irrelevants apt-key warnings
-    export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1" \
     # Disable all debian user interaction
-    && export DEBIAN_FRONTEND="noninteractive" \
-    && apt-get --quiet --yes -o=Dpkg::Use-Pty=0 --no-install-recommends --verbose-versions install \
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         python3-pip \
     && pip3 install ansible-core==${ANSIBLE_CORE_VERSION} \
 {{- end }}

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -18,10 +18,13 @@ ARG GOMPLATE_VERSION=3.11.3
 ENV container="docker"
 
 RUN \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
     # Backports
-    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get --quiet --allow-releaseinfo-change update \
+    && apt-get --quiet --yes --purge --auto-remove dist-upgrade \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
         sudo \
         curl \
@@ -62,7 +65,9 @@ FROM base AS system
 ARG DEBIAN
 
 RUN \
-    apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
       openssh-client \
       sshpass \
       python3 python3-pip \
@@ -75,11 +80,13 @@ RUN \
 {{ if .Vars.system.docker -}}
 # Docker
 RUN \
-    printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
     && curl -sSL https://download.docker.com/linux/debian/gpg \
         | apt-key add - \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli
 
 {{ end -}}
@@ -98,7 +105,9 @@ RUN \
     " \
     export PIPX_HOME="/usr/local" \
     export PIPX_BIN_DIR="/usr/local/bin" \
-    && apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
       ${BUILD_PACKAGES} \
     {{- if $ansibleLint.version }}
     # Ansible Lint
@@ -121,6 +130,6 @@ RUN \
     {{- end }}
     {{- end }}
     {{- end }}
-    && apt-get purge --yes --autoremove ${BUILD_PACKAGES}
+    && apt-get --quiet --yes --autoremove purge ${BUILD_PACKAGES}
 
 {{ end -}}

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -18,10 +18,13 @@ ARG GOMPLATE_VERSION=3.11.3
 ENV container="docker"
 
 RUN \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
     # Backports
-    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get --quiet --allow-releaseinfo-change update \
+    && apt-get --quiet --yes --purge --auto-remove dist-upgrade \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
         sudo \
         curl \
@@ -63,7 +66,9 @@ ARG DEBIAN
 ARG VIM_GNUPG_VERSION=2.7.1
 
 RUN \
-    apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         jq \
     # Vim Gnupg
     && mkdir -p /usr/share/vim/vimfiles/pack/plugins/start/vim-gnupg \
@@ -74,11 +79,13 @@ RUN \
 {{ if .Vars.system.docker -}}
 # Docker
 RUN \
-    printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
     && curl -sSL https://download.docker.com/linux/debian/gpg \
         | apt-key add - \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli
 
 {{ end -}}
@@ -219,11 +226,13 @@ RUN \
     BUILD_PACKAGES="pipx python3-venv gcc libpython3-dev" \
     export PIPX_HOME="/usr/local" \
     export PIPX_BIN_DIR="/usr/local/bin" \
-    && apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
       python3 \
       ${BUILD_PACKAGES} \
     && pipx install python-openstackclient=={{ $openstack.version }} \
-    && apt-get purge --yes --autoremove ${BUILD_PACKAGES} \
+    && apt-get --quiet --yes --autoremove purge ${BUILD_PACKAGES} \
     # Bash completion
     && openstack complete > /etc/bash_completion.d/openstack
 
@@ -236,14 +245,16 @@ RUN \
     BUILD_PACKAGES="pipx python3-venv gcc libpython3-dev" \
     export PIPX_HOME="/usr/local" \
     export PIPX_BIN_DIR="/usr/local/bin" \
-    && apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
       python3 \
       ${BUILD_PACKAGES} \
     && pipx install python-swiftclient=={{ $swift.version }} \
     {{ if $swift.keystone.version -}}
     && pipx inject python-swiftclient python-keystoneclient=={{ $swift.keystone.version }} \
     {{ end -}}
-    && apt-get purge --yes --autoremove ${BUILD_PACKAGES}
+    && apt-get --quiet --yes --autoremove purge ${BUILD_PACKAGES}
 
 {{ end -}}
 

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -18,10 +18,13 @@ ARG GOMPLATE_VERSION=3.11.3
 ENV container="docker"
 
 RUN \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
     # Backports
-    printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && printf "deb http://deb.debian.org/debian ${DEBIAN}-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get --quiet --allow-releaseinfo-change update \
+    && apt-get --quiet --yes --purge --auto-remove dist-upgrade \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
         sudo \
         curl \
@@ -62,17 +65,21 @@ FROM base AS system
 ARG DEBIAN
 
 RUN \
-    apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
       unzip
 
 {{ if .Vars.system.docker -}}
 # Docker
 RUN \
-    printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb https://download.docker.com/linux/debian ${DEBIAN} stable" > /etc/apt/sources.list.d/docker.list \
     && curl -sSL https://download.docker.com/linux/debian/gpg \
         | apt-key add - \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli
 
 {{ end -}}
@@ -80,21 +87,25 @@ RUN \
 # Nginx
 {{ $nginx := .Vars.system.nginx -}}
 RUN \
-    printf "deb http://nginx.org/packages/debian/ ${DEBIAN} nginx" > /etc/apt/sources.list.d/nginx.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb http://nginx.org/packages/debian/ ${DEBIAN} nginx" > /etc/apt/sources.list.d/nginx.list \
     && curl -sSL http://nginx.org/keys/nginx_signing.key \
         | apt-key add - \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         nginx={{ $nginx.version }}.*
 
 # Php
 {{ $php := .Vars.system.php -}}
 RUN \
-    printf "deb https://packages.sury.org/php/ ${DEBIAN} main" > /etc/apt/sources.list.d/php.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb https://packages.sury.org/php/ ${DEBIAN} main" > /etc/apt/sources.list.d/php.list \
     && curl -sSL https://packages.sury.org/php/apt.gpg \
         -o /etc/apt/trusted.gpg.d/php.gpg \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         php{{ $php.version }}-cli \
         php{{ $php.version }}-fpm \
         php{{ $php.version }}-opcache \
@@ -123,14 +134,16 @@ RUN \
 {{ if $nodejs.version -}}
 # Nodejs
 RUN \
-    printf "deb https://deb.nodesource.com/node_{{ $nodejs.version }}.x ${DEBIAN} main" > /etc/apt/sources.list.d/node.list \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && printf "deb https://deb.nodesource.com/node_{{ $nodejs.version }}.x ${DEBIAN} main" > /etc/apt/sources.list.d/node.list \
     && curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key \
         | apt-key add - \
     && printf "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg \
         | apt-key add - \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get --quiet update \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         nodejs \
         yarn
 
@@ -139,7 +152,9 @@ RUN \
 {{ if .Vars.deploy.inventory -}}
 # Ansistrano
 RUN \
-    apt-get install --yes --no-install-recommends \
+    # Disable all debian user interaction
+    export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         openssh-client \
         ansible \
     && ansible-galaxy install --roles-path /usr/share/ansible/roles \


### PR DESCRIPTION
- no more too-conscientious `APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="1"`
- no more too-conscientious `-o=Dpkg::Use-Pty=0`
- `DEBIAN_FRONTEND="noninteractive"` for the masses !
- `--quiet` everywhere
- `--allow-releaseinfo-change` for all updates
- `dist-upgrade` (with `--yes --purge --auto-remove`) after update everywhere
- `--verbose-versions` for all install