### PR TITLE
[Lazy - Symfony] Introduce up/WAIT and stop make targets

### DIFF
--- a/lazy.symfony/.manala/Makefile.tmpl
+++ b/lazy.symfony/.manala/Makefile.tmpl
@@ -22,11 +22,18 @@ ifndef DOCKER
 
 HELP += $(call help_section, System)
 
-HELP += $(call help,up,   Create and start local system)
+HELP += $(call help,up,   Create and start local system (WAIT))
 up:
 	@$(call log, Builds$(,) creates and starts docker containers…)
-	$(_docker_compose) up
+	$(_docker_compose) up \
+		$(if $(WAIT), --wait)
 .PHONY: up
+
+HELP += $(call help,stop, Stop local system)
+stop:
+	@$(call log, Stop docker containers…)
+	$(_docker_compose) stop
+.PHONY: stop
 
 HELP += $(call help,sh,   Open a local system shell)
 sh:

--- a/lazy.symfony/.manala/docker/compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker/compose.yaml.tmpl
@@ -30,6 +30,12 @@ services:
             MYSQL_DATABASE: project
             MYSQL_USER: project
             MYSQL_PASSWORD: project
+        healthcheck:
+            test: mysqladmin ping --silent --host 0.0.0.0
+            interval: 30s
+            timeout: 30s
+            retries: 3
+            start_period: 0s
 
 {{- if .Vars.system.phpmyadmin.version }}
 
@@ -66,8 +72,8 @@ services:
         restart: always
         user: root
         ports:
-            - {{ .Vars.system.maildev.port }}:80
-        command: ["--web", "80", "--smtp", "25"]
+            - {{ .Vars.system.maildev.port }}:1080
+        command: ["--smtp", "25"]
 
 {{- end }}
 


### PR DESCRIPTION
```shell
make up WAIT=1
...
make stop
```

This implies:
- having a functionnal healtchek for MariaDB container
- set back the local maildev http port to 1080, so that the internal healthcheck could work