### PR TITLE
[Elao - App - Docker] Use native docker network extra hosts

### DIFF
--- a/elao.app.docker/.manala/ansible/inventories/system.development.yaml.tmpl
+++ b/elao.app.docker/.manala/ansible/inventories/system.development.yaml.tmpl
@@ -35,9 +35,6 @@ system:
             system_influxdb: {{ not (empty .Vars.system.influxdb.version) | ternary "true" "false" }}
             # Locales
             system_locales: true
-            # Network
-            system_network: {{ not (empty .Vars.system.network.hosts) | ternary "true" "false" }}
-            {{- dict "system_network_hosts" .Vars.system.network.hosts | toYaml | nindent 12 }}
             # Nginx
             system_nginx: {{ not (empty .Vars.system.nginx.configs) | ternary "true" "false" }}
             # Ngrok

--- a/elao.app.docker/.manala/ansible/system.yaml
+++ b/elao.app.docker/.manala/ansible/system.yaml
@@ -195,12 +195,6 @@
       host = 127.0.0.1
       user = root
 
-    ###########
-    # Network #
-    ###########
-
-    manala_network_hosts: "{{ system_network_hosts }}"
-
     #########
     # Nginx #
     #########
@@ -333,11 +327,6 @@
         name: apt
       when: system_apt
       tags: [apt]
-
-    - import_role:
-        name: network
-      when: system_network
-      tags: [network]
 
     - import_role:
         name: locales

--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -97,6 +97,12 @@ services:
           {{- $env = set $env "COMPOSER_MEMORY_LIMIT" -1 }}
         {{- end }}
         {{- dict "environment" $env | toYaml | nindent 8 }}
+        {{- if .Vars.system.network.hosts }}
+        extra_hosts:
+            {{- range $ip, $host := .Vars.system.network.hosts }}
+            - "{{ $host }}:{{ $ip }}"
+            {{- end }}
+        {{- end }}
         volumes:
             - ../..:/srv/app
 


### PR DESCRIPTION
`/etc/hosts` is read-only in docker containers, but docker (and docker compose) offers a way to add extra hosts via https://docs.docker.com/compose/compose-file/#extra_hosts