### PR TITLE
[Elao - App - Docker] Switch zsh and apt roles

### DIFF
--- a/elao.app.docker/.manala/ansible/system.yaml
+++ b/elao.app.docker/.manala/ansible/system.yaml
@@ -319,14 +319,14 @@
   tasks:
 
     - import_role:
-        name: zsh
-      when: system_zsh
-      tags: [zsh]
-
-    - import_role:
         name: apt
       when: system_apt
       tags: [apt]
+
+    - import_role:
+        name: zsh
+      when: system_zsh
+      tags: [zsh]
 
     - import_role:
         name: locales


### PR DESCRIPTION
So that apt rules could be applied to zsh package.