### PR TITLE
[Elao - App - Docker] Increase ansible-galaxy timeout

### DIFF
--- a/elao.app.docker/.manala/ansible/ansible.mk
+++ b/elao.app.docker/.manala/ansible/ansible.mk
@@ -33,6 +33,7 @@ endif
 
 define manala_ansible_galaxy_collection_install
 	$(MANALA_ANSIBLE_GALAXY_BIN) collection install \
+		--timeout 60 \
 		--upgrade \
 		--requirements-file
 endef


### PR DESCRIPTION
This *SHOULD* solve some of the provision errors due to timeout with ansible galaxy servers