### PR TITLE
[Elao - App - Docker] Disable elasticsearch security

### DIFF
--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -63,6 +63,7 @@ services:
             discovery.type: single-node
             http.cors.allow-origin: "*"
             http.cors.enabled: "true"
+            xpack.security.enabled: "false"
         command: >
             sh -c
             "{{- range $plugin := $.Vars.system.elasticsearch.plugins }}((elasticsearch-plugin list|grep {{ $plugin }}) || elasticsearch-plugin install --batch --verbose {{ $plugin }}) && {{ end -}}


### PR DESCRIPTION
Elasticsearch 8 comes with security enabled by default, so that https is forced.

To continue to use elasticsearch in development without https, let's force security disablement, even for lower versions.