### PR TITLE
[Elao - App - Docker] Fix elasticsearch 5 docker command entrypoint

### DIFF
--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -67,7 +67,11 @@ services:
         command: >
             sh -c
             "{{- range $plugin := $.Vars.system.elasticsearch.plugins }}((elasticsearch-plugin list|grep {{ $plugin }}) || elasticsearch-plugin install --batch --verbose {{ $plugin }}) && {{ end -}}
+            {{- if le (.Vars.system.elasticsearch.version|int) 5 }}
+            exec bin/es-docker"
+            {{- else }}
             exec docker-entrypoint.sh"
+            {{- end }}
         network_mode: service:app
         healthcheck:
             test: curl --silent --fail --output /dev/null http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow


### PR DESCRIPTION
This is simply not the same as the upper versions :)