### PR TITLE
[Lazy] Update components

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -46,13 +46,13 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     ansible:
-        # @schema {"enum": ["2.14.2", "2.13.7", "2.12.10"]}
+        # @schema {"enum": ["2.14.3", "2.13.8", "2.12.10"]}
         # @option {"label": "Ansible version"}
         version: ~
         # @schema {"type": ["null", "string"]}
         config: ~
     ansible-lint:
-        # @schema {"enum": [null, "6.12.1", "6.11.0", "6.10.2"]}
+        # @schema {"enum": [null, "6.14.2", "6.13.1", "6.12.2"]}
         # @option {"label": "Ansible-lint version"}
         version: ~
     molecule:

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.3"
+ARG GOMPLATE_VERSION="3.11.4"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -13,11 +13,11 @@ system:
         config: |
             # Ssh config
     ansible:
-        version: 2.14.2
+        version: 2.14.3
         config: |
             # Ansible config
     ansible-lint:
-        version: 6.12.1
+        version: 6.14.2
     molecule:
         version: 4.0.4
         plugins:

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -43,11 +43,11 @@ system:
         # @schema {"enum": [null, "0.3.21"]}
         version: ~
     kubectl:
-        # @schema {"enum": ["1.26.1", "1.25.6", "1.24.10", "1.23.16", "1.22.17", "1.21.14", "1.20.15", "1.19.16", "1.18.20"]}
+        # @schema {"enum": ["1.26.2", "1.25.7", "1.24.11", "1.23.17", "1.22.17", "1.21.14", "1.20.15"]}
         # @option {"label": "Kubectl version"}
         version: ~
     helm:
-        # @schema {"enum": [null, "3.11.0", "3.10.3", "3.9.4", "3.8.2"]}
+        # @schema {"enum": [null, "3.11.2", "3.10.3", "3.9.4"]}
         # @option {"label": "Helm version"}
         version: ~
         # @schema {
@@ -66,15 +66,15 @@ system:
         # }
         plugins: []
     helmfile:
-        # @schema {"enum": [null, "0.150.0"]}
+        # @schema {"enum": [null, "0.151.0"]}
         # @option {"label": "Helmfile version"}
         version: ~
     k9s:
-        # @schema {"enum": [null, "0.26.7"]}
+        # @schema {"enum": [null, "0.27.3"]}
         # @option {"label": "K9s version"}
         version: ~
     stern:
-        # @schema {"enum": [null, "1.22.0"]}
+        # @schema {"enum": [null, "1.23.0"]}
         # @option {"label": "Stern version"}
         version: ~
     kube-prompt:
@@ -82,7 +82,7 @@ system:
         # @option {"label": "Kube-prompt version"}
         version: ~
     popeye:
-        # @schema {"enum": [null, "0.10.1"]}
+        # @schema {"enum": [null, "0.11.1"]}
         # @option {"label": "Popeye version"}
         version: ~
     knsk:
@@ -90,7 +90,7 @@ system:
         # @option {"label": "Kubernetes namespace killer version"}
         version: ~
     vault:
-        # @schema {"enum": [null, "1.12.2", "1.11.6", "1.10.9", "1.9.10"]}
+        # @schema {"enum": [null, "1.13.0", "1.12.4", "1.11.8"]}
         # @option {"label": "Vault version"}
         version: ~
     rclone:
@@ -98,19 +98,19 @@ system:
         # @option {"label": "Rclone version"}
       version: ~
     openstack:
-        # @schema {"enum": [null, "6.0.0"]}
+        # @schema {"enum": [null, "6.2.0"]}
         # @option {"label": "Openstack client version"}
       version: ~
     swift:
-        # @schema {"enum": [null, "4.1.0"]}
+        # @schema {"enum": [null, "4.2.0"]}
         # @option {"label": "Swift client version"}
       version: ~
       keystone:
-        # @schema {"enum": [null, "5.0.1"]}
+        # @schema {"enum": [null, "5.1.0"]}
         # @option {"label": "Swift keystone client version"}
         version: ~
     scw:
-        # @schema {"enum": [null, "2.8.0"]}
+        # @schema {"enum": [null, "2.12.0"]}
         # @option {"label": "Scaleway cli version"}
       version: ~
     sops:
@@ -118,6 +118,6 @@ system:
         # @option {"label": "Sops version"}
       version: ~
     aws:
-        # @schema {"enum": [null, "2.9.17"]}
+        # @schema {"enum": [null, "2.11.1"]}
         # @option {"label": "AWS cli version"}
       version: ~

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.3"
+ARG GOMPLATE_VERSION="3.11.4"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.
@@ -166,7 +166,7 @@ complete -F __start_helmfile hfi\n\
 {{ if $k9s.version -}}
 # K9s
 RUN \
-    curl -sSL "https://github.com/derailed/k9s/releases/download/v{{ $k9s.version }}/k9s_Linux_{{ include "arch_map" (dict "amd64" "x86_64" "arm64" "arm64") }}.tar.gz" \
+    curl -sSL "https://github.com/derailed/k9s/releases/download/v{{ $k9s.version }}/k9s_Linux_{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}.tar.gz" \
         | bsdtar -xvf - -C /usr/local/bin k9s
 
 {{ end -}}

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -10,37 +10,37 @@ system:
     goss:
         version: 0.3.21
     kubectl:
-        version: 1.26.1
+        version: 1.26.2
     helm:
-        version: 3.11.0
+        version: 3.11.2
         plugins:
             - url: https://github.com/databus23/helm-diff
               version: 3.6.0
     helmfile:
-        version: 0.150.0
+        version: 0.151.0
     k9s:
-        version: 0.26.7
+        version: 0.27.3
     stern:
-        version: 1.22.0
+        version: 1.23.0
     kube-prompt:
         version: 1.0.11
     popeye:
-        version: 0.10.1
+        version: 0.11.1
     knsk:
         version: "1.0"
     vault:
-        version: 1.12.2
+        version: 1.13.0
     rclone:
       version: 1.61.1
     openstack:
-      version: 6.0.0
+      version: 6.2.0
     swift:
-      version: 4.1.0
+      version: 4.2.0
       keystone:
-        version: 5.0.1
+        version: 5.1.0
     scw:
-      version: 2.8.0
+      version: 2.12.0
     sops:
       version: 3.7.3
     aws:
-      version: 2.9.17
+      version: 2.11.1

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.3"
+ARG GOMPLATE_VERSION="3.11.4"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.


### PR DESCRIPTION
# All

- gomplate 3.11.3 -> 3.11.4

# Lazy - Ansible

- ansible 2.14.2 -> 2.14.3
- ansible-lint 6.12.1 -> 6.14.2

# Lazy - Kubernetes

- kubectl 1.26.1 -> 1.26.2
- kubectl 1.25.6 -> 1.25.7
- kubectl 1.24.10 -> 1.24.11
- kubectl 1.23.16-> 1.23.17
- kubectl ~~1.19.16~~
- kubectl ~~1.18.20~~
- helm 3.11.0 -> 3.11.2
- helm ~~3.82~~
- helmfile 0.150.0 -> 0.151.0
- k9s 0.26.7 -> 0.27.3
- stern 1.22.0-> 1.23.0
- popeye 0.10.1 -> 0.11.1
- vault 1.13.0
- vault 1.12.2 -> 1.12.4
- vault 1.11.6 -> 1.11.8
- vault ~~1.10.9~~
- vault ~~1.9.10~~
- openstack 6.0.0 -> 6.2.0
- swift 4.1.0 -> 4.2.0
- swift.keystone 5.0.1 -> 5.1.0
- scw 2.8.0 -> 2.12.0
- aws 2.9.17 -> 2.11.1
