### PR TITLE
[Lazy - Ansible] Pipx and dependencies

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -54,18 +54,17 @@ system:
         version: ~
         # @schema {"type": ["null", "string"]}
         config: ~
+        # @schema {"items": {"type": "string"}}
+        dependencies: []
     ansible-lint:
         # @schema {"enum": [null, "6.14.2", "6.13.1", "6.12.2"]}
         # @option {"label": "Ansible-lint version"}
         version: ~
+        # @schema {"items": {"type": "string"}}
+        dependencies: []
     molecule:
         # @schema {"enum": [null, "4.0.4"]}
         # @option {"label": "Molecule version"}
         version: ~
-        plugins:
-            # @schema {"enum": [null, "23.0.0"]}
-            # @option {"label": "Molecule Plugins version"}
-            version: ~
-            azure: false
-            docker: false
-            gce: false
+        # @schema {"items": {"type": "string"}}
+        dependencies: []

--- a/lazy.ansible/.manala.yaml.tmpl
+++ b/lazy.ansible/.manala.yaml.tmpl
@@ -60,11 +60,4 @@ system:
     {{- if $molecule.version }}
     molecule:
         version: {{ $molecule.version | toYaml }}
-        {{- if $molecule.plugins.version }}
-        plugins:
-            version: {{ $molecule.plugins.version | toYaml }}
-            azure: false
-            docker: false
-            gce: false
-        {{- end }}
     {{- end }}

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -64,18 +64,20 @@ RUN \
 # System #
 ##########
 
-ARG PIPX_HOME="/usr/local"
-ARG PIPX_BIN_DIR="/usr/local/bin"
+ENV PIPX_HOME="/usr/local"
+ENV PIPX_BIN_DIR="/usr/local/bin"
 
 RUN \
     apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         openssh-client \
         sshpass \
-        python3 python3-pip \
+        python3 \
+        pipx \
         python3-argcomplete \
-        python3-apt {{- if .Vars.system.docker }} python3-docker {{- end }} \
         shellcheck \
+    # Sudo
+    && echo "Defaults env_keep += \"PIPX_*\"" > /etc/sudoers.d/pipx \
     # Bash completion
     && activate-global-python-argcomplete3 --dest /etc/bash_completion.d \
     # Clean
@@ -105,56 +107,58 @@ RUN \
 
 {{ end -}}
 
-# Ansible
 {{ $ansible := .Vars.system.ansible -}}
+# Ansible
 RUN \
-    pip3 --no-cache-dir --disable-pip-version-check install \
+    pipx install --pip-args="--no-cache-dir" \
         ansible-core=={{ $ansible.version }}
+    {{- if $ansible.dependencies }} \
+    && pipx inject --pip-args="--no-cache-dir" ansible-core \
+        {{- range $i, $dependency := $ansible.dependencies }}
+        {{- if $i }} \{{- end }}
+        {{ $dependency }}
+        {{- end }}
+    {{- end }}
 
 {{ $ansibleLint := index .Vars.system "ansible-lint" -}}
-{{ $molecule := .Vars.system.molecule -}}
-{{ if or $ansibleLint.version $molecule.version -}}
+{{ if $ansibleLint.version -}}
+# Ansible Lint
 RUN \
     BUILD_PACKAGES=( \
-        pipx \
-        {{- if $ansibleLint.version }}
         libpython3-dev gcc \
-        {{- end }}
     ) \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         "${BUILD_PACKAGES[@]}" \
-    {{- if $ansibleLint.version }}
-    # Ansible Lint
-    && pipx install \
+    && pipx install --pip-args="--no-cache-dir" \
         ansible-lint=={{ $ansibleLint.version }} \
-    {{- end }}
-    {{- if $molecule.version }}
-    # Molecule
-    && pipx install \
-        molecule=={{ $molecule.version }} \
-    && _MOLECULE_COMPLETE=bash_source molecule > /etc/bash_completion.d/molecule \
-    {{- if $molecule.plugins.version }}
-    && pipx inject molecule \
-        molecule-plugins=={{ $molecule.plugins.version }} \
-    {{- if $molecule.plugins.azure }}
-    && pipx inject molecule \
-        molecule-plugins[azure]=={{ $molecule.plugins.version }} \
-    {{- end }}
-    {{- if $molecule.plugins.docker }}
-    && pipx inject molecule \
-        molecule-plugins[docker]=={{ $molecule.plugins.version }} \
-    {{- end }}
-    {{- if $molecule.plugins.gce }}
-    && pipx inject molecule \
-        molecule-plugins[gce]=={{ $molecule.plugins.version }} \
-    {{- end }}
-    {{- end }}
+    {{- if $ansibleLint.dependencies }}
+    && pipx inject --pip-args="--no-cache-dir" ansible-lint \
+        {{- range $dependency := $ansibleLint.dependencies }}
+        {{ $dependency }} \
+        {{- end }}
     {{- end }}
     # Clean
     && apt-get --quiet --yes --autoremove purge \
         "${BUILD_PACKAGES[@]}" \
     && rm -rf /var/lib/apt/lists/*
+
+{{ end -}}
+
+{{ $molecule := .Vars.system.molecule -}}
+{{ if $molecule.version -}}
+# Molecule
+RUN \
+    pipx install --pip-args="--no-cache-dir" \
+        molecule=={{ $molecule.version }} \
+    && _MOLECULE_COMPLETE=bash_source molecule > /etc/bash_completion.d/molecule \
+    {{- if $molecule.dependencies }}
+    && pipx inject --pip-args="--no-cache-dir" molecule \
+        {{- range $i, $dependency := $molecule.dependencies }}
+        {{- if $i }} \{{- end }}
+        {{ $dependency }}
+        {{- end }}
+    {{- end }}
 
 {{ end -}}
 

--- a/lazy.ansible/.manala/etc/profile.d/message.sh.tmpl
+++ b/lazy.ansible/.manala/etc/profile.d/message.sh.tmpl
@@ -11,15 +11,21 @@ printf "\033[34m    =- =- -=.--\"\033[0m\n"
 printf "\n"
 {{- $ansible := .Vars.system.ansible }}
 printf " \033[36m‣ ansible \033[35m{{ $ansible.version }}\033[0m\n"
+{{- range $dependency := $ansible.dependencies }}
+printf "    \033[36m· {{ $dependency }}\033[0m\n"
+{{- end }}
 {{- $ansibleLint := index .Vars.system "ansible-lint" }}
 {{- if $ansibleLint.version }}
 printf " \033[36m‣ ansible-lint \033[35m{{ $ansibleLint.version }}\033[0m\n"
+{{- range $dependency := $ansibleLint.dependencies }}
+printf "    \033[36m· {{ $dependency }}\033[0m\n"
+{{- end }}
 {{- end }}
 {{- $molecule := .Vars.system.molecule }}
 {{- if $molecule.version }}
 printf " \033[36m‣ molecule \033[35m{{ $molecule.version }}\033[0m\n"
-{{- if $molecule.plugins.version }}
-printf " \033[36m‣ molecule-plugins \033[35m{{ $molecule.plugins.version }}\033[0m\n"
+{{- range $dependency := $molecule.dependencies }}
+printf "    \033[36m· {{ $dependency }}\033[0m\n"
 {{- end }}
 {{- end }}
 

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -19,12 +19,14 @@ system:
         version: 2.14.3
         config: |
             # Ansible config
+        dependencies:
+            - hvac==1.1.0
     ansible-lint:
         version: 6.14.2
+        dependencies:
+            - pytest==7.2.2
     molecule:
         version: 4.0.4
-        plugins:
-            version: 23.0.0
-            azure: true
-            docker: true
-            gce: true
+        dependencies:
+            - molecule-plugins==23.0.0
+            - molecule-plugins[docker]==23.0.0

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -46,16 +46,29 @@ command:
     exit-status: 0
     stdout:
       - ansible [core {{ .Vars.system.ansible.version }}]
+  sudo pipx runpip ansible-core list:
+    exit-status: 0
+    stdout:
+      - "/ansible-core(\\s+){{ .Vars.system.ansible.version }}/"
+      - "/hvac(\\s+)\\d+\\.\\d+\\.\\d+/"
   # Ansible Lint
   ansible-lint --nocolor --version:
     exit-status: 0
     stdout:
       - ansible-lint {{ (index .Vars.system "ansible-lint").version }}
+  sudo pipx runpip ansible-lint list:
+    exit-status: 0
+    stdout:
+      - "/ansible-lint(\\s+){{ (index .Vars.system "ansible-lint").version }}/"
+      - "/pytest(\\s+)\\d+\\.\\d+\\.\\d+/"
   # Molecule
   FORCE_COLOR=0 molecule --version:
     exit-status: 0
     stdout:
       - molecule {{ .Vars.system.molecule.version }}
-      - azure:{{ .Vars.system.molecule.plugins.version }} from molecule_plugin
-      - docker:{{ .Vars.system.molecule.plugins.version }} from molecule_plugin
-      - gce:{{ .Vars.system.molecule.plugins.version }} from molecule_plugin
+      - "/docker:\\d+\\.\\d+\\.\\d+ from molecule_plugin/"
+  sudo pipx runpip molecule list:
+    exit-status: 0
+    stdout:
+      - "/molecule(\\s+){{ .Vars.system.molecule.version }}/"
+      - "/molecule-plugins(\\s+)\\d+\\.\\d+\\.\\d+/"


### PR DESCRIPTION
- [x] Switch `ansible` installation from global pip to pipx/venv
- [x] Leave pipx installed in the container
- [x] Use pipx/pip without cache (hey, we are in a container)
- [x] Remove `python3-docker` apt package, as it could obviously not be used by a pipx/venv ansible package (see example below for docker usage)
- [x] Remove useless `python3-apt` apt package, as it is only need in a managed node, and not a controller node.
- [x] Handle `ansible`, `ansible-lint` and `molecule` dependencies
- [x] Remove hardcoded and too specific molecule plugins handling

Before:
```yaml
system:
    ...
    molecule:
        ....
        plugins:
            version: 23.0.0
            docker: true
```

After:
```yaml
system:
    ...
    ansible:
        ...
        dependencies:
            # Collection community.docker
            - docker==6.0.1
            # Collection community.hashi_vault
            - hvac==1.1.0 
    ...
    molecule:
        ....
        dependencies:
            - molecule-plugins==23.0.0
            - molecule-plugins[docker]==23.0.0
```
