### PR TITLE
[Lazy] GitLab CI system

### DIFF
--- a/lazy.ansible/.manala/gitlab/system.yaml
+++ b/lazy.ansible/.manala/gitlab/system.yaml
@@ -1,0 +1,6 @@
+.manala.system.setup:
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:manala_system_setup[collapsed=true]\r\e[0KSet up system"
+    - make manala.docker.compose COMMAND="pull --ignore-buildable"
+    - make manala.docker.compose COMMAND="build"
+    - echo -e "\e[0Ksection_end:`date +%s`:manala_system_setup\r\e[0K"

--- a/lazy.kubernetes/.manala/gitlab/system.yaml
+++ b/lazy.kubernetes/.manala/gitlab/system.yaml
@@ -1,0 +1,6 @@
+.manala.system.setup:
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:manala_system_setup[collapsed=true]\r\e[0KSet up system"
+    - make manala.docker.compose COMMAND="pull --ignore-buildable"
+    - make manala.docker.compose COMMAND="build"
+    - echo -e "\e[0Ksection_end:`date +%s`:manala_system_setup\r\e[0K"

--- a/lazy.symfony/.manala/gitlab/system.yaml
+++ b/lazy.symfony/.manala/gitlab/system.yaml
@@ -1,0 +1,6 @@
+.manala.system.setup:
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:manala_system_setup[collapsed=true]\r\e[0KSet up system"
+    - make manala.docker.compose COMMAND="pull --ignore-buildable"
+    - make manala.docker.compose COMMAND="build"
+    - echo -e "\e[0Ksection_end:`date +%s`:manala_system_setup\r\e[0K"


### PR DESCRIPTION
Not really folichon-folichon, but introduce a way to separate and delegate system setup.

Usage in `.gitlab-ci.yml`:
```yaml
...
include: .manala/gitlab/system.yaml
...
job:
  ...
  before_script:
    - !reference [.manala.system.setup, script]
  script:
    ...
```