### PR TITLE
[All] No dot in docker compose name

### DIFF
--- a/elao.app.docker/.manala/docker/compose.yaml.tmpl
+++ b/elao.app.docker/.manala/docker/compose.yaml.tmpl
@@ -1,4 +1,4 @@
-name: {{ .Vars.project.name }}
+name: {{ .Vars.project.name | replace "." "-"}}
 
 services:
 

--- a/lazy.ansible/.manala/docker/compose.yaml.tmpl
+++ b/lazy.ansible/.manala/docker/compose.yaml.tmpl
@@ -1,6 +1,6 @@
 {{- $now := dateInZone "20060102150405" (now) "UTC" -}}
 
-name: {{ .Vars.project.name }}
+name: {{ .Vars.project.name | replace "." "-" }}
 
 services:
 

--- a/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
+++ b/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
@@ -1,6 +1,6 @@
 {{- $now := dateInZone "20060102150405" (now) "UTC" -}}
 
-name: {{ .Vars.project.name }}
+name: {{ .Vars.project.name | replace "." "-" }}
 
 services:
 

--- a/lazy.symfony/.manala/docker/compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker/compose.yaml.tmpl
@@ -1,6 +1,6 @@
 {{- $now := dateInZone "20060102150405" (now) "UTC" -}}
 
-name: {{ .Vars.project.name }}
+name: {{ .Vars.project.name | replace "." "-" }}
 
 services:
 


### PR DESCRIPTION
Docker compose seems to dislike dots in its name.

`compose.yaml`:
```yaml
name: foo.bar
...
```

> `name Does not match pattern '^[a-z0-9][a-z0-9_-]*$'`