### PR TITLE
[Lazy] Fix xargs interoperability

### DIFF
--- a/lazy.ansible/.manala/Makefile.tmpl
+++ b/lazy.ansible/.manala/Makefile.tmpl
@@ -70,7 +70,7 @@ clean:
 	$(manala_docker) images \
 		--filter reference='{{ .Vars.project.name }}:*' \
 		--format "{{ `{{.ID}}` }}" \
-			| xargs $(manala_docker) rmi --force
+			| xargs -r $(manala_docker) rmi --force
 	@$(call manala_log, Delete cache dir…)
 	rm -Rf $(MANALA_DIR)/$(MANALA_CACHE_DIR)
 .PHONY: clean

--- a/lazy.kubernetes/.manala/Makefile.tmpl
+++ b/lazy.kubernetes/.manala/Makefile.tmpl
@@ -70,7 +70,7 @@ clean:
 	$(manala_docker) images \
 		--filter reference='{{ .Vars.project.name }}:*' \
 		--format "{{ `{{.ID}}` }}" \
-			| xargs $(manala_docker) rmi --force
+			| xargs -r $(manala_docker) rmi --force
 	@$(call manala_log, Delete cache dir…)
 	rm -Rf $(MANALA_DIR)/$(MANALA_CACHE_DIR)
 .PHONY: clean

--- a/lazy.symfony/.manala/Makefile.tmpl
+++ b/lazy.symfony/.manala/Makefile.tmpl
@@ -90,7 +90,7 @@ clean:
 	$(manala_docker) images \
 		--filter reference='{{ .Vars.project.name }}:*' \
 		--format "{{ `{{.ID}}` }}" \
-			| xargs $(manala_docker) rmi --force
+			| xargs -r $(manala_docker) rmi --force
 	@$(call manala_log, Delete cache dir…)
 	rm -Rf $(MANALA_DIR)/$(MANALA_CACHE_DIR)
 .PHONY: clean


### PR DESCRIPTION
Fix xargs interoperability between gnu version (mainly linux) where `-r`  (`--no-run-if-empty`) is mandatory and bsd version (mainly macos) where it's implied.