### PR TITLE
[Elao - App - Docker] Auto select appropriated ref to checkout for setup & release according to manala.yaml deliveries config

### DIFF
--- a/elao.app.docker/.manala/github/deliveries/setup/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/setup/action.yaml.tmpl
@@ -12,7 +12,8 @@ inputs:
   ref:
     description: Ref
     required: false
-    default: main
+    # default depends on the selected app+tier (delivery) if none explicitly provided.
+    # E.g: 'main' for production, 'staging' for staging, etc… depending on .manala.yaml deliveries config.
   env:
     description: Env vars as a single string
     required: false
@@ -30,15 +31,6 @@ runs:
   using: composite
   steps:
 
-    {{ `- name: >
-        Checkout delivery
-        ${{ inputs.app && format('{0}@', inputs.app) || '' }}${{ inputs.tier }}
-        (ref "${{ inputs.ref }}")
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.ref }}
-        path: deliveries/${{ inputs.app && format('{0}/', inputs.app) || '' }}${{ inputs.tier }}` }}
-
     {{- range $i, $delivery := .Vars.deliveries }}
     {{- $delivery_name := $delivery.tier }}
     {{- $delivery_if := printf "inputs.tier == '%s'" $delivery.tier }}
@@ -48,11 +40,18 @@ runs:
       {{- $delivery_if = printf "inputs.app == '%s' && inputs.tier == '%s'" $delivery.app $delivery.tier }}
       {{- $delivery_id_suffix = printf "%s_%s" $delivery.app $delivery.tier }}
     {{- end }}
-    {{- $delivery_ref := printf "${{ inputs.ref || '%s' }}" (or (get $delivery "ref") "master") }}
+    {{- $delivery_ref := printf "${{ inputs.ref || '%s' }}" (or (get $delivery "ref") "main") }}
 
     ##{{ repeat (len $delivery_name) "#" }}##
     # {{ $delivery_name }} #
     ##{{ repeat (len $delivery_name) "#" }}##
+
+    - name: Checkout {{ $delivery_name }} (ref "{{ $delivery_ref }}")
+      if: {{ $delivery_if }}
+      uses: actions/checkout@v3
+      with:
+        ref: {{ $delivery_ref }}
+        {{ `path: deliveries/${{ inputs.app && format('{0}/', inputs.app) || '' }}${{ inputs.tier }}` }}
 
     - name: Setup SSH Key for {{ $delivery_name }}
       id: setup_ssh_key_{{ $delivery_id_suffix }}


### PR DESCRIPTION
## For releases

Generally speaking, we want : 
- to checkout the `main` / `master` branch for production releases
- to checkout the `staging` branch for staging, staging-1, staging-x releases
- checkout an explicit ref to create a release from when providing a `ref` to the workflow from the UI or command-line / API (`input.ref`)

Hopefully, we already precise the branch to use for the release on each delivery in the `.manala.yaml` config:

```yml
##############
# Deliveries #
##############

deliveries:

  - &delivery_back
    app: back
    tier: production
    ref: main # <- HERE
```

> **Warning**: for repositories with a `master` branch, do precise the `ref: master` entry in the config now rather than leaving empty. 

So we can use this to generate the sub-action to auto-select the proper branch when no `input.ref` is explicitly given.

## For deploys

Same rules apply for checkout and setup the container as for release.
BUT, the `input.ref` is different, since it refers to a git reference of the **_release repository_**, not the one running the workflow.
➜ It's the `ref` to checkout during deployment before uploading the build app to the serveur. _A.k.a: a delivery / deploy ref_.

By default, it use the latest release available, but one can use the `input.ref` to re-deploy a previous release.