### PR TITLE
[Elao - App - Docker] Add convenient db target to reset db + fixtures

### DIFF
--- a/elao.app.docker/Makefile.dist
+++ b/elao.app.docker/Makefile.dist
@@ -37,6 +37,11 @@ install@staging:
 # Database #
 ############
 
+## Database - Reset hard the database with schema and fixtures
+db:
+	$(call manala_confirm, Are you sure to reset the database? You will lose all your data. Fixtures will be loaded again., y)
+	make db.reset db.fixtures
+
 ## Database - Init (create+schema)
 db.install: db.create db.update-force
 


### PR DESCRIPTION
Just use `make install db` to get back on a project really quick ⚡ 