### PR TITLE
[Lazy] Update components

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -41,7 +41,7 @@ system:
     mount: []
     docker: false
     goss:
-        # @schema {"enum": [null, "0.3.21"]}
+        # @schema {"enum": [null, "0.4.2", "0.3.23"]}
         version: ~
     apt:
         # @schema {"items": {"type": "string"}}
@@ -53,7 +53,7 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     ansible:
-        # @schema {"enum": ["2.14.3", "2.13.8", "2.12.10"]}
+        # @schema {"enum": ["2.15.5", "2.14.11", "2.13.13"]}
         # @option {"label": "Ansible version"}
         version: ~
         # @schema {"type": ["null", "string"]}
@@ -61,7 +61,7 @@ system:
         # @schema {"items": {"type": "string"}}
         dependencies: []
     ansible-lint:
-        # @schema {"enum": [null, "6.14.2", "6.13.1", "6.12.2"]}
+        # @schema {"enum": [null, "6.14.6", "6.13.1", "6.12.2"]}
         # @option {"label": "Ansible-lint version"}
         version: ~
         # @schema {"items": {"type": "string"}}

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -2,7 +2,7 @@
 # Base #
 ########
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.4"
+ARG GOMPLATE_VERSION="3.11.5"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.
@@ -20,9 +20,7 @@ ENV container="docker"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    # Backports
-    echo "deb http://deb.debian.org/debian {{ include "os_release" "VERSION_CODENAME" }}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get --quiet update \
+    apt-get --quiet update \
     && apt-get --quiet --yes --purge --autoremove upgrade \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
@@ -38,12 +36,10 @@ RUN \
         less \
         vim \
         socat \
-    # Apt keyrings (debian < bookworm)
-    && mkdir --verbose --parents /etc/apt/keyrings \
     # User
     && addgroup --gid ${MANALA_GROUP_ID} lazy \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
-    && mkdir --verbose --parents /run/user/${MANALA_USER_ID} && chown lazy:lazy /run/user/${MANALA_USER_ID} \
+    && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
     # Gosu
     && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
@@ -54,7 +50,7 @@ RUN \
         --output /usr/local/bin/gomplate \
     && chmod +x /usr/local/bin/gomplate \
     # Bash completion
-    && mkdir --verbose --parents /etc/bash_completion.d \
+    && install --verbose --mode 0755 --directory /etc/bash_completion.d \
     # Oh My Bash
     && git clone https://github.com/ohmybash/oh-my-bash.git /usr/local/share/oh-my-bash \
     # Clean
@@ -84,7 +80,7 @@ RUN \
     # Sudo
     && echo "Defaults env_keep += \"PIPX_*\"" > /etc/sudoers.d/pipx \
     # Bash completion
-    && activate-global-python-argcomplete3 --dest /etc/bash_completion.d \
+    && activate-global-python-argcomplete --dest /etc/bash_completion.d \
     # Clean
     && rm -rf /var/lib/apt/lists/*
 
@@ -92,8 +88,13 @@ RUN \
 # Docker
 RUN \
     curl -sSL https://download.docker.com/linux/debian/gpg \
-        | gpg --dearmor --output /etc/apt/keyrings/docker.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian {{ include "os_release" "VERSION_CODENAME" }} stable" > /etc/apt/sources.list.d/docker.list \
+        --output /etc/apt/keyrings/docker.asc \
+    && printf "Types: deb\n\
+URIs: https://download.docker.com/linux/debian\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: stable\n\
+Signed-By: /etc/apt/keyrings/docker.asc\n\
+" > /etc/apt/sources.list.d/docker.sources \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli \

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -8,7 +8,7 @@ project:
 system:
     docker: true
     goss:
-        version: 0.3.21
+        version: 0.4.2
     apt:
         packages:
             - jq
@@ -19,17 +19,17 @@ system:
         config: |
             # Ssh config
     ansible:
-        version: 2.14.3
+        version: 2.15.5
         config: |
             # Ansible config
         dependencies:
-            - hvac==1.1.0
+            - hvac==1.2.1
     ansible-lint:
-        version: 6.14.2
+        version: 6.14.6
         dependencies:
-            - pytest==7.3.2
+            - pytest==7.4.2
     molecule:
         version: 5.0.1
         dependencies:
-            - molecule-plugins==23.4.1
-            - molecule-plugins[docker]==23.4.1
+            - molecule-plugins==23.5.0
+            - molecule-plugins[docker]==23.5.0

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -29,18 +29,32 @@ user:
     shell: /bin/bash
 
 file:
+  # Base
+  /etc/os-release:
+    exists: true
+    contents:
+      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
   # Git
   /etc/gitconfig:
     exists: true
-    contains:
-      - # Git config
+    contents:
+      - "# Git config template"
   # Ssh
-  /etc/ssh/ssh_config:
+  /etc/ssh/ssh_config.d/ssh_config.conf:
     exists: true
-    contains:
-      - # Ssh config
+    contents:
+      - "# Ssh config template"
 
 command:
+  # Base
+  gosu --version:
+    exit-status: 0
+    stdout:
+      - "1.16"
+  gomplate --version:
+    exit-status: 0
+    stdout:
+      - gomplate version 3.11.5
   # Goss
   goss --version:
     exit-status: 0

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -41,7 +41,7 @@ system:
     mount: []
     docker: false
     goss:
-        # @schema {"enum": [null, "0.4.0", "0.3.21"]}
+        # @schema {"enum": [null, "0.4.2", "0.3.23"]}
         version: ~
     apt:
         # @schema {"items": {"type": "string"}}
@@ -50,11 +50,11 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     kubectl:
-        # @schema {"enum": ["1.28.1", "1.27.5", "1.26.2", "1.25.7", "1.24.11", "1.23.17", "1.22.17", "1.21.14", "1.20.15"]}
+        # @schema {"enum": ["1.28.3", "1.27.7", "1.26.10", "1.25.15", "1.24.17", "1.23.17", "1.22.17", "1.21.14", "1.20.15"]}
         # @option {"label": "Kubectl version"}
         version: ~
     helm:
-        # @schema {"enum": [null, "3.12.3", "3.11.2", "3.10.3", "3.9.4"]}
+        # @schema {"enum": [null, "3.13.1", "3.12.3", "3.11.3", "3.10.3"]}
         # @option {"label": "Helm version"}
         version: ~
         # @schema {
@@ -73,15 +73,15 @@ system:
         # }
         plugins: []
     helmfile:
-        # @schema {"enum": [null, "0.156.0", "0.151.0"]}
+        # @schema {"enum": [null, "0.157.0", "0.156.0"]}
         # @option {"label": "Helmfile version"}
         version: ~
     k9s:
-        # @schema {"enum": [null, "0.27.3"]}
+        # @schema {"enum": [null, "0.27.4"]}
         # @option {"label": "K9s version"}
         version: ~
     stern:
-        # @schema {"enum": [null, "1.23.0"]}
+        # @schema {"enum": [null, "1.26.0"]}
         # @option {"label": "Stern version"}
         version: ~
     kube-prompt:
@@ -97,34 +97,34 @@ system:
         # @option {"label": "Kubernetes namespace killer version"}
         version: ~
     vault:
-        # @schema {"enum": [null, "1.14.1", "1.13.0", "1.12.4", "1.11.8"]}
+        # @schema {"enum": [null, "1.15.0", "1.14.4", "1.13.8", "1.12.11"]}
         # @option {"label": "Vault version"}
         version: ~
     rclone:
-        # @schema {"enum": [null, "1.61.1"]}
+        # @schema {"enum": [null, "1.64.1"]}
         # @option {"label": "Rclone version"}
       version: ~
     openstack:
-        # @schema {"enum": [null, "6.2.0"]}
+        # @schema {"enum": [null, "6.3.0"]}
         # @option {"label": "Openstack client version"}
       version: ~
     swift:
-        # @schema {"enum": [null, "4.2.0"]}
+        # @schema {"enum": [null, "4.4.0"]}
         # @option {"label": "Swift client version"}
       version: ~
       keystone:
-        # @schema {"enum": [null, "5.1.0"]}
+        # @schema {"enum": [null, "5.2.0"]}
         # @option {"label": "Swift keystone client version"}
         version: ~
     scw:
-        # @schema {"enum": [null, "2.19.0"]}
+        # @schema {"enum": [null, "2.23.0"]}
         # @option {"label": "Scaleway cli version"}
       version: ~
     sops:
-        # @schema {"enum": [null, "3.7.3"]}
+        # @schema {"enum": [null, "3.8.1"]}
         # @option {"label": "Sops version"}
       version: ~
     aws:
-        # @schema {"enum": [null, "2.13.3"]}
+        # @schema {"enum": [null, "2.13.27"]}
         # @option {"label": "AWS cli version"}
       version: ~

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -2,7 +2,7 @@
 # Base #
 ########
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.4"
+ARG GOMPLATE_VERSION="3.11.5"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.
@@ -20,9 +20,7 @@ ENV container="docker"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    # Backports
-    echo "deb http://deb.debian.org/debian {{ include "os_release" "VERSION_CODENAME" }}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get --quiet update \
+    apt-get --quiet update \
     && apt-get --quiet --yes --purge --autoremove upgrade \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
@@ -38,12 +36,10 @@ RUN \
         less \
         vim \
         socat \
-    # Apt keyrings (debian < bookworm)
-    && mkdir --verbose --parents /etc/apt/keyrings \
     # User
     && addgroup --gid ${MANALA_GROUP_ID} lazy \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
-    && mkdir --verbose --parents /run/user/${MANALA_USER_ID} && chown lazy:lazy /run/user/${MANALA_USER_ID} \
+    && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
     # Gosu
     && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
@@ -54,7 +50,7 @@ RUN \
         --output /usr/local/bin/gomplate \
     && chmod +x /usr/local/bin/gomplate \
     # Bash completion
-    && mkdir --verbose --parents /etc/bash_completion.d \
+    && install --verbose --mode 0755 --directory /etc/bash_completion.d \
     # Oh My Bash
     && git clone https://github.com/ohmybash/oh-my-bash.git /usr/local/share/oh-my-bash \
     # Clean
@@ -80,7 +76,7 @@ RUN \
         {{- end }}
     {{- end }}
     # Vim Gnupg
-    && mkdir --verbose --parents /usr/share/vim/vimfiles/pack/plugins/start/vim-gnupg \
+    && install --verbose --mode 0755 --directory /usr/share/vim/vimfiles/pack/plugins/start/vim-gnupg \
     && curl -sSL https://github.com/jamessan/vim-gnupg/releases/download/v${VIM_GNUPG_VERSION}/vim-gnupg-v${VIM_GNUPG_VERSION}.tar.gz \
         | bsdtar -xvf - -C /usr/share/vim/vimfiles/pack/plugins/start/vim-gnupg --strip-components=1 vim-gnupg-${VIM_GNUPG_VERSION} \
     && echo "let g:GPGPreferSymmetric = 1" >> /etc/vim/vimrc \
@@ -91,8 +87,13 @@ RUN \
 # Docker
 RUN \
     curl -sSL https://download.docker.com/linux/debian/gpg \
-        | gpg --dearmor --output /etc/apt/keyrings/docker.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian {{ include "os_release" "VERSION_CODENAME" }} stable" > /etc/apt/sources.list.d/docker.list \
+        --output /etc/apt/keyrings/docker.asc \
+    && printf "Types: deb\n\
+URIs: https://download.docker.com/linux/debian\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: stable\n\
+Signed-By: /etc/apt/keyrings/docker.asc\n\
+" > /etc/apt/sources.list.d/docker.sources \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli \

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -8,7 +8,7 @@ project:
 system:
     docker: true
     goss:
-        version: 0.3.21
+        version: 0.4.2
     apt:
         packages:
             - jq
@@ -16,18 +16,18 @@ system:
         config: |
             # Git config
     kubectl:
-        version: 1.26.2
+        version: 1.28.3
     helm:
-        version: 3.11.2
+        version: 3.13.1
         plugins:
             - url: https://github.com/databus23/helm-diff
-              version: 3.6.0
+              version: 3.8.1
     helmfile:
-        version: 0.151.0
+        version: 0.157.0
     k9s:
-        version: 0.27.3
+        version: 0.27.4
     stern:
-        version: 1.23.0
+        version: 1.26.0
     kube-prompt:
         version: 1.0.11
     popeye:
@@ -35,18 +35,18 @@ system:
     knsk:
         version: "1.0"
     vault:
-        version: 1.13.0
+        version: 1.15.0
     rclone:
-      version: 1.61.1
+      version: 1.64.1
     openstack:
-      version: 6.2.0
+      version: 6.3.0
     swift:
-      version: 4.2.0
+      version: 4.4.0
       keystone:
-        version: 5.1.0
+        version: 5.2.0
     scw:
-      version: 2.12.0
+      version: 2.23.0
     sops:
-      version: 3.7.3
+      version: 3.8.1
     aws:
-      version: 2.11.1
+      version: 2.13.27

--- a/lazy.kubernetes/test/goss.yaml
+++ b/lazy.kubernetes/test/goss.yaml
@@ -20,20 +20,34 @@ user:
     shell: /bin/bash
 
 file:
+  # Base
+  /etc/os-release:
+    exists: true
+    contents:
+      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
   # Git
   /etc/gitconfig:
     exists: true
-    contains:
-      - # Git config
+    contents:
+      - "# Git config template"
 
 command:
+  # Base
+  gosu --version:
+    exit-status: 0
+    stdout:
+      - "1.16"
+  gomplate --version:
+    exit-status: 0
+    stdout:
+      - gomplate version 3.11.5
   # Goss
   goss --version:
     exit-status: 0
     stdout:
       - goss version v{{ .Vars.system.goss.version }}
   # Kubectl
-  kubectl version --client false --short:
+  kubectl version --client true:
     exit-status: 0
     stdout:
       - "Client Version: v{{ .Vars.system.kubectl.version }}"

--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -42,7 +42,7 @@ system:
     mount: []
     docker: false
     goss:
-        # @schema {"enum": [null, "0.3.21"]}
+        # @schema {"enum": [null, "0.4.2", "0.3.23"]}
         version: ~
     apt:
         # @schema {"items": {"type": "string"}}
@@ -52,7 +52,7 @@ system:
         config: ~
     nginx:
         # @option {"label": "Nginx version"}
-        # @schema {"enum": ["1.20"]}
+        # @schema {"enum": [1.24]}
         version: ~
         # @schema {"type": "integer", "exclusiveMinimum": 1024, "maximum": 65535}
         port: 8000
@@ -74,13 +74,13 @@ system:
         port: 8306
     phpmyadmin:
         # @option {"label": "PhpMyAdmin version"}
-        # @schema {"enum": [null, 5.1]}
+        # @schema {"enum": [null, "5.2.1"]}
         version: ~
         # @schema {"type": "integer", "exclusiveMinimum": 1024, "maximum": 65535}
         port: 8300
     maildev:
         # @option {"label": "MailDev version"}
-        # @schema {"enum": [null, "2.0.5"]}
+        # @schema {"enum": [null, "2.1.0"]}
         version: ~
         # @schema {"type": "integer", "exclusiveMinimum": 1024, "maximum": 65535}
         port: 8025

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -2,7 +2,7 @@
 # Base #
 ########
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -10,7 +10,7 @@ ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
 ARG GOSU_VERSION="1.16"
-ARG GOMPLATE_VERSION="3.11.4"
+ARG GOMPLATE_VERSION="3.11.5"
 
 # The 'container' environment variable tells systemd that it's running inside a
 # Docker container environment.
@@ -20,9 +20,7 @@ ENV container="docker"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    # Backports
-    echo "deb http://deb.debian.org/debian {{ include "os_release" "VERSION_CODENAME" }}-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get --quiet update \
+    apt-get --quiet update \
     && apt-get --quiet --yes --purge --autoremove upgrade \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         s6 \
@@ -38,12 +36,10 @@ RUN \
         less \
         vim \
         socat \
-    # Apt keyrings (debian < bookworm)
-    && mkdir --verbose --parents /etc/apt/keyrings \
     # User
     && addgroup --gid ${MANALA_GROUP_ID} lazy \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
-    && mkdir --verbose --parents /run/user/${MANALA_USER_ID} && chown lazy:lazy /run/user/${MANALA_USER_ID} \
+    && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
     # Gosu
     && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
@@ -54,7 +50,7 @@ RUN \
         --output /usr/local/bin/gomplate \
     && chmod +x /usr/local/bin/gomplate \
     # Bash completion
-    && mkdir --verbose --parents /etc/bash_completion.d \
+    && install --verbose --mode 0755 --directory /etc/bash_completion.d \
     # Oh My Bash
     && git clone https://github.com/ohmybash/oh-my-bash.git /usr/local/share/oh-my-bash \
     # Clean
@@ -80,8 +76,13 @@ RUN \
 # Docker
 RUN \
     curl -sSL https://download.docker.com/linux/debian/gpg \
-        | gpg --dearmor --output /etc/apt/keyrings/docker.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian {{ include "os_release" "VERSION_CODENAME" }} stable" > /etc/apt/sources.list.d/docker.list \
+        --output /etc/apt/keyrings/docker.asc \
+    && printf "Types: deb\n\
+URIs: https://download.docker.com/linux/debian\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: stable\n\
+Signed-By: /etc/apt/keyrings/docker.asc\n\
+" > /etc/apt/sources.list.d/docker.sources \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         docker-ce-cli \
@@ -104,8 +105,13 @@ RUN \
 {{ $nginx := .Vars.system.nginx -}}
 RUN \
     curl -sSL http://nginx.org/keys/nginx_signing.key \
-        | gpg --dearmor --output /etc/apt/keyrings/nginx.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/debian/ {{ include "os_release" "VERSION_CODENAME" }} nginx" > /etc/apt/sources.list.d/nginx.list \
+        --output /etc/apt/keyrings/nginx.asc \
+    && printf "Types: deb\n\
+URIs: http://nginx.org/packages/debian\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: nginx\n\
+Signed-By: /etc/apt/keyrings/nginx.asc\n\
+" > /etc/apt/sources.list.d/nginx.sources \
     && printf "Package: nginx\n\
 Pin: version {{ $nginx.version }}.*\n\
 Pin-Priority: 1000\n\
@@ -120,8 +126,13 @@ Pin-Priority: 1000\n\
 {{ $php := .Vars.system.php -}}
 RUN \
     curl -sSL https://packages.sury.org/php/apt.gpg \
-        --output /etc/apt/keyrings/sury.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/sury.gpg] https://packages.sury.org/php/ {{ include "os_release" "VERSION_CODENAME" }} main" > /etc/apt/sources.list.d/php.list \
+        --output /etc/apt/keyrings/sury_php.gpg \
+    && printf "Types: deb\n\
+URIs: https://packages.sury.org/php/\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: main\n\
+Signed-By: /etc/apt/keyrings/sury_php.gpg\n\
+" > /etc/apt/sources.list.d/sury_php.sources \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         php{{ $php.version }}-cli \
@@ -139,7 +150,7 @@ RUN \
         {{- end }}
     && apt-get --quiet --yes --purge --autoremove upgrade \
     && phpdismod xdebug \
-    && mkdir --verbose --parents /run/php \
+    && install --verbose --mode 0755 --directory /run/php \
     && update-alternatives --install /usr/sbin/php-fpm php-fpm /usr/sbin/php-fpm{{ $php.version }} 1 \
     && update-alternatives --install /etc/php/default php-config-default /etc/php/{{ $php.version }} 1 \
     # Composer
@@ -156,15 +167,25 @@ RUN \
 # Nodejs
 RUN \
     curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key \
-        | gpg --dearmor --output /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ $nodejs.version }}.x {{ include "os_release" "VERSION_CODENAME" }} main" > /etc/apt/sources.list.d/nodejs.list \
+        --output /etc/apt/keyrings/nodesource.asc \
+    && printf "Types: deb\n\
+URIs: https://deb.nodesource.com/node_{{ $nodejs.version }}.x\n\
+Suites: {{ include "os_release" "VERSION_CODENAME" }}\n\
+Components: main\n\
+Signed-By: /etc/apt/keyrings/nodesource.asc\n\
+" > /etc/apt/sources.list.d/nodesource.sources \
     && printf "Package: nodejs\n\
 Pin: origin deb.nodesource.com\n\
 Pin-Priority: 1000\n\
 " > /etc/apt/preferences.d/nodejs \
     && curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg \
-        | gpg --dearmor --output /etc/apt/keyrings/yarn.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+        --output /etc/apt/keyrings/yarn.asc \
+    && printf "Types: deb\n\
+URIs:  https://dl.yarnpkg.com/debian/\n\
+Suites: stable\n\
+Components: main\n\
+Signed-By: /etc/apt/keyrings/yarn.asc\n\
+" > /etc/apt/sources.list.d/yarn.sources \
     && apt-get --quiet update \
     && apt-get --quiet --yes --no-install-recommends --verbose-versions install \
         nodejs \
@@ -182,7 +203,7 @@ RUN \
         openssh-client \
         ansible \
     && ansible-galaxy install --roles-path /usr/share/ansible/roles \
-        ansistrano.deploy,3.10.0 \
+        ansistrano.deploy,3.14.0 \
         ansistrano.rollback,3.1.0 \
     # Clean
     && rm -rf /var/lib/apt/lists/*

--- a/lazy.symfony/test/.manala.yaml
+++ b/lazy.symfony/test/.manala.yaml
@@ -8,7 +8,7 @@ project:
 system:
     docker: true
     goss:
-        version: 0.3.21
+        version: 0.4.2
     apt:
         packages:
             - jq
@@ -16,7 +16,7 @@ system:
         config: |
             # Git config
     nginx:
-        version: "1.20"
+        version: 1.24
     php:
         version: 8.1
         extensions:
@@ -24,11 +24,11 @@ system:
     nodejs:
         version: 16
     mariadb:
-        version: 10.4
+        version: 10.5
     phpmyadmin:
-        version: 5.1
+        version: 5.2.1
     maildev:
-        version: 2.0.5
+        version: 2.1.0
 
 ##########
 # Deploy #

--- a/lazy.symfony/test/goss.yaml
+++ b/lazy.symfony/test/goss.yaml
@@ -28,13 +28,27 @@ user:
     shell: /bin/bash
 
 file:
+  # Base
+  /etc/os-release:
+    exists: true
+    contents:
+      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
   # Git
   /etc/gitconfig:
     exists: true
-    contains:
-      - # Git config
+    contents:
+      - "# Git config template"
 
 command:
+  # Base
+  gosu --version:
+    exit-status: 0
+    stdout:
+      - "1.16"
+  gomplate --version:
+    exit-status: 0
+    stdout:
+      - gomplate version 3.11.5
   # Goss
   goss --version:
     exit-status: 0
@@ -79,8 +93,8 @@ command:
   ansible-galaxy role list:
     exit-status: 0
     stdout:
-      - # /usr/share/ansible/roles
-      - "- ansistrano.deploy, 3.10.0"
+      - "# /usr/share/ansible/roles"
+      - "- ansistrano.deploy, 3.14.0"
       - "- ansistrano.rollback, 3.1.0"
 
 process:


### PR DESCRIPTION
# All

- debian bullseye -> bookworm
- gomplate 3.11.4 -> 3.11.5

# Lazy - Ansible

- goss 0.4.2
- goss 0.3.21 -> 0.3.23
- ansible 2.15.5
- ansible 2.14.3 -> 2.14.11
- ansible 2.13.8 -> 2.13.13
- ansible ~~2.12.10~~
- ansible-lint 6.14.2 -> 6.14.6

# Lazy - Kubernetes

- goss 0.4.0 -> 0.4.2
- goss 0.3.21 -> 0.3.23
- kubectl 1.28.1 -> 1.28.3
- kubectl 1.27.5 -> 1.27.7
- kubectl 1.26.2 -> 1.26.10
- kubectl 1.24.11-> 1.24.17
- helm 3.13.1
- helm 3.11.2 -> 3.11.3
- helm ~~3.9.4~~
- helmfile 0.157.0
- helmfile 0.150.0 -> 0.151.0
- helmfile ~~0.155.1~~
- k9s 0.27.3 -> 0.27.4
- stern 1.23.0-> 1.26.0
- popeye 0.10.1 -> 0.11.1
- vault 1.15.0
- vault 1.14.1 -> 1.14.4
- vault 1.13.0 -> 1.13.8
- vault 1.12.4 -> 1.12.11
- vault ~~1.11.8~~
- rclone 1.61.1 -> 1.64.1
- openstack 6.2.0 -> 6.3.0
- swift 4.2.0 -> 4.4.0
- swift.keystone 5.1.0 -> 5.2.0
- scw 2.19.0 -> 2.23.0
- sops 3.7.3 -> 3.8.1
- aws 2.13.3 -> 2.13.27

# Lazy - Symfony

- ansistrano.deploy 3.10.0 -> 3.14.0
- goss 0.4.2
- goss 0.3.21 -> 0.3.23
- nginx 1.20 -> 1.24
- phpmyadmin 5.1 -> 5.2.1
- maildev 2.0.5 -> 2.1.0
