### PR TITLE
[Lazy] Disable full path oh-my-bash print after cd into a directory

### DIFF
--- a/lazy.ansible/.manala/etc/profile.d/oh-my-bash.sh.tmpl
+++ b/lazy.ansible/.manala/etc/profile.d/oh-my-bash.sh.tmpl
@@ -131,3 +131,7 @@ source "$OSH"/oh-my-bash.sh
 # Example aliases
 # alias bashconfig="mate ~/.bashrc"
 # alias ohmybash="mate ~/.oh-my-bash"
+
+# Disable full path print after cd into a directory
+# See: https://github.com/ohmybash/oh-my-bash/issues/201
+unset CDPATH

--- a/lazy.kubernetes/.manala/etc/profile.d/oh-my-bash.sh.tmpl
+++ b/lazy.kubernetes/.manala/etc/profile.d/oh-my-bash.sh.tmpl
@@ -129,3 +129,7 @@ source "$OSH"/oh-my-bash.sh
 # Example aliases
 # alias bashconfig="mate ~/.bashrc"
 # alias ohmybash="mate ~/.oh-my-bash"
+
+# Disable full path print after cd into a directory
+# See: https://github.com/ohmybash/oh-my-bash/issues/201
+unset CDPATH

--- a/lazy.symfony/.manala/etc/profile.d/oh-my-bash.sh.tmpl
+++ b/lazy.symfony/.manala/etc/profile.d/oh-my-bash.sh.tmpl
@@ -140,3 +140,7 @@ source "$OSH"/oh-my-bash.sh
 # Example aliases
 # alias bashconfig="mate ~/.bashrc"
 # alias ohmybash="mate ~/.oh-my-bash"
+
+# Disable full path print after cd into a directory
+# See: https://github.com/ohmybash/oh-my-bash/issues/201
+unset CDPATH


### PR DESCRIPTION
That was really annoying...
```shell
09:35:55 lazy@foo bar ±| |→ cd baz
/home/foo/bar/baz
09:35:55 lazy@foo baz ±| |→
```

See: https://github.com/ohmybash/oh-my-bash/issues/201