### PR TITLE
[Elao - App -Docker] Allow directory slash in app name

### DIFF
--- a/elao.app.docker/.manala.yaml
+++ b/elao.app.docker/.manala.yaml
@@ -166,7 +166,7 @@ system:
 #         "delivery": {"type": "object", "$id": "#delivery",
 #             "additionalProperties": false,
 #             "properties": {
-#                 "app": {"type": "string", "pattern": "^[a-z]+$"},
+#                 "app": {"type": "string", "pattern": "^[\/a-z]+$"},
 #                 "tier": {"type": "string", "pattern": "^[\\w-/]+$"},
 #                 "ref": {"type": "string", "pattern": "^[\\w-/]+$"},
 #                 "release_repo": {"type": "string"},

--- a/elao.app.docker/.manala/github/deliveries/setup/action.yaml.tmpl
+++ b/elao.app.docker/.manala/github/deliveries/setup/action.yaml.tmpl
@@ -55,10 +55,9 @@ runs:
 
     {{ if hasKey $delivery "github_ssh_key_secret" -}}
     - name: Setup SSH Key for {{ $delivery_name }}
-      id: setup_ssh_key_{{ $delivery_id_suffix }}
       if: {{ $delivery_if }}
       shell: bash
-      run: echo "ssh_key_secret={{ $delivery.github_ssh_key_secret }}" >> $GITHUB_OUTPUT
+      run: echo "MANALA_DELIVERIES_SSH_KEY_SECRET={{ $delivery.github_ssh_key_secret }}" >> $GITHUB_ENV
     {{- else -}}
     # No SSH key configured for {{ $delivery_name }}
     {{- end }}
@@ -77,8 +76,4 @@ runs:
         dir: deliveries/${{ inputs.app && format('{0}/', inputs.app) || '' }}${{ inputs.tier }}
         env: ${{ inputs.env }}
         ssh_key: >-
-          ${{ fromJSON(inputs.secrets)[steps[format(
-            'setup_ssh_key_{0}{1}',
-             inputs.app && format('{0}_', inputs.app) || '',
-             inputs.tier
-          )].outputs.ssh_key_secret] }}` }}
+          ${{ fromJSON(inputs.secrets)[env.MANALA_DELIVERIES_SSH_KEY_SECRET] }}` }}


### PR DESCRIPTION
So we can use release & deploy with Manala when the apps from a monorepo are placed in a subdir, like `apps/xxx`

### Done

- Fixed release on GitHub actions

### LATER

- fixup deploy on GitHub actions (`deployment_url`)