### PR TITLE
[Elao - App -Docker] Add default goal guard

### DIFF
--- a/elao.app.docker/Makefile.dist
+++ b/elao.app.docker/Makefile.dist
@@ -2,6 +2,17 @@
 
 -include .manala/Makefile
 
+ifneq ($(.DEFAULT_GOAL),help)
+.DEFAULT_GOAL := _default
+endif
+
+_default:
+	@printf '\n'
+	@printf '\033[33mWARNING:\033[39m\n'
+	@printf ' If you just call \033[3mmake\033[23m and read this, no default goal was defined explicitly.\n'
+	@printf ' This might be because the \033[3m.manala\033[23m folder is not included.\n'
+	@printf ' Hence, \033[3mmake help\033[23m command is not available.\n\n'
+
 define setup
 	$(MANALA_DOCKER_MAKE) install db.install build
 endef


### PR DESCRIPTION
Closes #409

- Si la tâche par défaut calculé par make n'est pas `help` (ce qu'on souhaite tjrs ds le contexte de la recipe), on exécute à la place une task `_default`, qui affiche un warning : 
  ![image](https://github.com/manala/manala-recipes/assets/2211145/eb59efd1-f21a-4743-9415-29425847fcc0)
- Cette tâche sera donc exécuté dans le cas où la release en staging/production n'inclue pas les makefile du `.manala` contenant le help
- Si le besoin se fait sentir pour un projet, il peut customiser la tâche par défaut.

> [!IMPORTANT]
> Attention, pour les projets mono repo, avec des projets dans des sous-dossiers et `Makefile` dédiée, il faudra répéter cette section depuis le Makefile racine vers chaque sous-projet.