### PR TITLE
[Lazy - Ansible] Remove argcomplete

### DIFF
--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -80,15 +80,12 @@ RUN \
         sshpass \
         python3 \
         pipx \
-        python3-argcomplete \
         shellcheck \
         {{- range $package := $apt.packages }}
         {{ $package }} \
         {{- end }}
     # Sudo
     && echo "Defaults env_keep += \"PIPX_*\"" > /etc/sudoers.d/pipx \
-    # Bash completion
-    && activate-global-python-argcomplete --dest /etc/bash_completion.d \
     # Clean
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This has *NEVER* worked and could *NEVER* works because ansible is installed in a venv via pipx, and could *NOT* have access to system python libraries.