### PR TITLE
[Lazy] Remove gosu

### DIFF
--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -9,7 +9,6 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="3.11.7"
 ARG DIRENV_VERSION="2.33.0"
 
@@ -45,10 +44,6 @@ RUN \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
     && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
-    # Gosu
-    && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-        --output /usr/local/bin/gosu \
-    && chmod +x /usr/local/bin/gosu \
     # Gomplate
     && curl -sSL "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
         --output /usr/local/bin/gomplate \

--- a/lazy.ansible/.manala/docker/entrypoint.sh
+++ b/lazy.ansible/.manala/docker/entrypoint.sh
@@ -54,4 +54,5 @@ if [ $# -eq 0 ] && [ -d "/etc/services.d" ]; then
 fi
 
 # Command
-exec gosu lazy "$@"
+export HOME="/home/lazy"
+exec s6-setuidgid lazy "$@"

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -47,10 +47,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "1.17"
   gomplate --version:
     exit-status: 0
     stdout:

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -9,7 +9,6 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="3.11.7"
 ARG DIRENV_VERSION="2.33.0"
 
@@ -45,10 +44,6 @@ RUN \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
     && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
-    # Gosu
-    && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-        --output /usr/local/bin/gosu \
-    && chmod +x /usr/local/bin/gosu \
     # Gomplate
     && curl -sSL "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
         --output /usr/local/bin/gomplate \

--- a/lazy.kubernetes/.manala/docker/entrypoint.sh
+++ b/lazy.kubernetes/.manala/docker/entrypoint.sh
@@ -54,4 +54,5 @@ if [ $# -eq 0 ] && [ -d "/etc/services.d" ]; then
 fi
 
 # Command
-exec gosu lazy "$@"
+export HOME="/home/lazy"
+exec s6-setuidgid lazy "$@"

--- a/lazy.kubernetes/test/goss.yaml
+++ b/lazy.kubernetes/test/goss.yaml
@@ -33,10 +33,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "1.17"
   gomplate --version:
     exit-status: 0
     stdout:

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -9,7 +9,6 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="3.11.7"
 ARG DIRENV_VERSION="2.33.0"
 
@@ -45,10 +44,6 @@ RUN \
     && adduser --home /home/lazy --shell /bin/bash --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy \
     && install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID} \
     && echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy \
-    # Gosu
-    && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-        --output /usr/local/bin/gosu \
-    && chmod +x /usr/local/bin/gosu \
     # Gomplate
     && curl -sSL "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
         --output /usr/local/bin/gomplate \

--- a/lazy.symfony/.manala/docker/entrypoint.sh
+++ b/lazy.symfony/.manala/docker/entrypoint.sh
@@ -54,4 +54,5 @@ if [ $# -eq 0 ] && [ -d "/etc/services.d" ]; then
 fi
 
 # Command
-exec gosu lazy "$@"
+export HOME="/home/lazy"
+exec s6-setuidgid lazy "$@"

--- a/lazy.symfony/test/goss.yaml
+++ b/lazy.symfony/test/goss.yaml
@@ -41,10 +41,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "1.17"
   gomplate --version:
     exit-status: 0
     stdout:


### PR DESCRIPTION
Remove [gosu](https://github.com/tianon/gosu) dependency, as `s6-setuidgid` (which is part of [s6](https://skarnet.org/software/s6/), already present in the container) performs the same service.

Note that unlike `gosu` (see: https://github.com/tianon/gosu/blob/b73cc93b6f5b5a045c397ff0f75190e33d853946/setup-user.go#L43), `s6-setuidgid` does not update the `HOME` environment variable to user home directory, leaving its value to `/root` (see: https://github.com/just-containers/s6-overlay/issues/165).
That's why we have to `export HOME="/home/lazy"` right before calling `s6-setuidgid`.