### PR TITLE
[Elao - App - Docker] Update ansible version test

### DIFF
--- a/elao.app.docker/test/goss.yaml
+++ b/elao.app.docker/test/goss.yaml
@@ -41,7 +41,7 @@ command:
   ansible --version:
     exit-status: 0
     stdout:
-      - ansible [core 2.15.5]
+      - "/ansible \\[core 2\\.15\\.\\d+\\]/"
   # Locales
   locale:
     exit-status: 0


### PR DESCRIPTION
It appears that `ansible` python packages requires `ansible-core` in a semantical version: 

```
'ansible-core ~= 2.15.5',
```

We have to adjust our ansible version test to use regex instead of fixed version.