### PR TITLE
[Elao - App -Docker] Force ansible_facts usage with ansible_date_time

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/tasks/markup.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/tasks/markup.yml
@@ -20,12 +20,12 @@
     git {{
       release_author|ternary(release_author|regex_replace(release_email_regex, '-c user.name="\g<name>" -c user.email="\g<email>"'), '')
     }} commit --allow-empty --message "Released {{
-      ansible_date_time.year
-      ~ ansible_date_time.month
-      ~ ansible_date_time.day
-      ~ ansible_date_time.hour
-      ~ ansible_date_time.minute
-      ~ ansible_date_time.second
+      ansible_facts.date_time.year
+      ~ ansible_facts.date_time.month
+      ~ ansible_facts.date_time.day
+      ~ ansible_facts.date_time.hour
+      ~ ansible_facts.date_time.minute
+      ~ ansible_facts.date_time.second
     }}
     Release repository commit: https://{{
       release_repo|regex_replace(release_git_url_regex, '\g<host>/\g<user>/\g<repository>')


### PR DESCRIPTION
Same as https://github.com/manala/manala-recipes/pull/432, but for the release markup feature