### PR TITLE
[Elao - App -Docker] Speed up git release

### DIFF
--- a/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
+++ b/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml
@@ -47,7 +47,7 @@
     git init
     && git checkout -b {{ release_ref }}
     && git remote add origin {{ release_repo }}
-    && git fetch
+    && git fetch --depth=1
     && (
       git show-ref -q origin/{{ release_ref }} ; rc=$? ;
       if [ $rc -eq 0 -o $rc -eq 1 ] ; then


### PR DESCRIPTION
With large git repo, git fetch [here](https://github.com/manala/manala-recipes/blob/master/elao.app.docker/.manala/ansible/roles/release/tasks/main.yml#L50) can be very long. The option --depth=1 will limit the fetched commit to the last one, improving the speed of the task.

On my project:

| Task | without --depth=1 | with --depth=1 |
|---|---|---|
| release : git > Init only | 3'49" | 1'18" |
| full release + deploy | 6'36" | 3'41" |