### PR TITLE
[Lazy] Handle "required" env_file

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -35,7 +35,21 @@ system:
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}
     # }
     env: {}
-    # @schema {"type": ["string", "array"]}
+    # @schema {
+    #     "type": ["string", "array"],
+    #     "items": {"oneOf": [
+    #         {"type": "string"},
+    #         {
+    #             "type": "object",
+    #             "properties": {
+    #                  "path": {"type": "string"},
+    #                  "required": {"type": "boolean"}
+    #             },
+    #             "required": ["path"],
+    #             "additionalProperties": false
+    #         }
+    #     ]}
+    # }
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []

--- a/lazy.ansible/.manala.yaml.tmpl
+++ b/lazy.ansible/.manala.yaml.tmpl
@@ -18,6 +18,10 @@ project:
 ##########
 
 system:
+    # env_file:
+    #     - .env
+    #     - path: .env.local
+    #       required: false
     # apt:
     #     packages:
     #         - jq

--- a/lazy.ansible/.manala/docker/compose.yaml.tmpl
+++ b/lazy.ansible/.manala/docker/compose.yaml.tmpl
@@ -33,7 +33,12 @@ services:
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:
             {{- range $file := .Vars.system.env_file }}
+              {{- if kindIs "map" $file }}
+              {{- $file := set $file "path" (printf "../../%s" $file.path) }}
+            - {{ $file | toYaml | indent 14 | trim }}
+              {{- else }}
             - ../../{{ $file }}
+              {{- end }}
             {{- end }}
         {{- else }}
         env_file: ../../{{ .Vars.system.env_file }}

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -10,7 +10,10 @@ system:
         TEST: test
     env_file:
         - .env.1
-        - .env.2
+        - path: .env.2
+          required: false
+        - path: .env.3
+          required: false
     docker: true
     goss:
         version: 0.4.8

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -35,7 +35,21 @@ system:
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}
     # }
     env: {}
-    # @schema {"type": ["string", "array"]}
+    # @schema {
+    #     "type": ["string", "array"],
+    #     "items": {"oneOf": [
+    #         {"type": "string"},
+    #         {
+    #             "type": "object",
+    #             "properties": {
+    #                  "path": {"type": "string"},
+    #                  "required": {"type": "boolean"}
+    #             },
+    #             "required": ["path"],
+    #             "additionalProperties": false
+    #         }
+    #     ]}
+    # }
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []

--- a/lazy.kubernetes/.manala.yaml.tmpl
+++ b/lazy.kubernetes/.manala.yaml.tmpl
@@ -18,6 +18,10 @@ project:
 ##########
 
 system:
+    # env_file:
+    #     - .env
+    #     - path: .env.local
+    #       required: false
     # apt:
     #     packages:
     #         - jq

--- a/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
+++ b/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
@@ -33,7 +33,12 @@ services:
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:
             {{- range $file := .Vars.system.env_file }}
+              {{- if kindIs "map" $file }}
+              {{- $file := set $file "path" (printf "../../%s" $file.path) }}
+            - {{ $file | toYaml | indent 14 | trim }}
+              {{- else }}
             - ../../{{ $file }}
+              {{- end }}
             {{- end }}
         {{- else }}
         env_file: ../../{{ .Vars.system.env_file }}

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -10,7 +10,10 @@ system:
         TEST: test
     env_file:
         - .env.1
-        - .env.2
+        - path: .env.2
+          required: false
+        - path: .env.3
+          required: false
     docker: true
     goss:
         version: 0.4.8

--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -36,7 +36,21 @@ system:
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}
     # }
     env: {}
-    # @schema {"type": ["string", "array"]}
+    # @schema {
+    #     "type": ["string", "array"],
+    #     "items": {"oneOf": [
+    #         {"type": "string"},
+    #         {
+    #             "type": "object",
+    #             "properties": {
+    #                  "path": {"type": "string"},
+    #                  "required": {"type": "boolean"}
+    #             },
+    #             "required": ["path"],
+    #             "additionalProperties": false
+    #         }
+    #     ]}
+    # }
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []

--- a/lazy.symfony/.manala.yaml.tmpl
+++ b/lazy.symfony/.manala.yaml.tmpl
@@ -18,6 +18,10 @@ project:
 ##########
 
 system:
+    # env_file:
+    #     - .env
+    #     - path: .env.local
+    #       required: false
     # apt:
     #     packages:
     #         - jq

--- a/lazy.symfony/.manala/docker/compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker/compose.yaml.tmpl
@@ -39,7 +39,12 @@ services:
         {{- if kindIs "slice" .Vars.system.env_file }}
         env_file:
             {{- range $file := .Vars.system.env_file }}
+              {{- if kindIs "map" $file }}
+              {{- $file := set $file "path" (printf "../../%s" $file.path) }}
+            - {{ $file | toYaml | indent 14 | trim }}
+              {{- else }}
             - ../../{{ $file }}
+              {{- end }}
             {{- end }}
         {{- else }}
         env_file: ../../{{ .Vars.system.env_file }}

--- a/lazy.symfony/test/.manala.yaml
+++ b/lazy.symfony/test/.manala.yaml
@@ -10,7 +10,10 @@ system:
         TEST: test
     env_file:
         - .env.1
-        - .env.2
+        - path: .env.2
+          required: false
+        - path: .env.3
+          required: false
     docker: true
     goss:
         version: 0.4.4


### PR DESCRIPTION
`env_file` could now be set as `required` `true`/`false`

```yaml
...
system:
    env_file:
        - .env.1
        - path: .env.2
          required: true
        - path: .env.3
          required: false
...
```

See: https://docs.docker.com/reference/compose-file/services/#env_file

