### PR TITLE
[Lazy] Fix deprecated env usage

### DIFF
--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -21,7 +21,7 @@ ARG YQ_VERSION="4.44.3"
 ENV container="docker"
 
 # Default locale
-ENV LANG C.UTF-8
+ENV LANG="C.UTF-8"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -21,7 +21,7 @@ ARG YQ_VERSION="4.44.3"
 ENV container="docker"
 
 # Default locale
-ENV LANG C.UTF-8
+ENV LANG="C.UTF-8"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -21,7 +21,7 @@ ARG YQ_VERSION="4.44.3"
 ENV container="docker"
 
 # Default locale
-ENV LANG C.UTF-8
+ENV LANG="C.UTF-8"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
See: https://docs.docker.com/reference/build-checks/legacy-key-value-format/