### PR TITLE
[Lazy - Kubernetes] Remove kube-prompt

### DIFF
--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -98,10 +98,6 @@ system:
         # @schema {"enum": [null, "1.30.0"]}
         # @option {"label": "Stern version"}
         version: ~
-    kube-prompt:
-        # @schema {"enum": [null, "1.0.11"]}
-        # @option {"label": "Kube-prompt version"}
-        version: ~
     popeye:
         # @schema {"enum": [null, "0.21.5"]}
         # @option {"label": "Popeye version"}

--- a/lazy.kubernetes/.manala.yaml.tmpl
+++ b/lazy.kubernetes/.manala.yaml.tmpl
@@ -48,11 +48,6 @@ system:
     stern:
         version: {{ .Vars.system.stern.version | toYaml }}
     {{- end }}
-    {{- $kubePrompt := index .Vars.system "kube-prompt" -}}
-    {{- if $kubePrompt.version }}
-    kube-prompt:
-        version: {{ $kubePrompt.version | toYaml }}
-    {{- end }}
     {{- if .Vars.system.popeye.version }}
     popeye:
         version: {{ .Vars.system.popeye.version | toYaml }}

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -211,16 +211,6 @@ RUN \
 
 {{ end -}}
 
-{{ $kubePrompt := index .Vars.system "kube-prompt" -}}
-{{ if $kubePrompt.version -}}
-# Kube Prompt
-RUN \
-    curl -sSLf "https://github.com/c-bata/kube-prompt/releases/download/v{{ $kubePrompt.version }}/kube-prompt_v{{ $kubePrompt.version }}_linux_{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}.zip" \
-        | bsdtar -xvf - -C /usr/local/bin \
-    && chmod +x /usr/local/bin/kube-prompt
-
-{{ end -}}
-
 {{ $popeye := .Vars.system.popeye -}}
 {{ if $popeye.version -}}
 # Popeye

--- a/lazy.kubernetes/.manala/etc/profile.d/message.sh.tmpl
+++ b/lazy.kubernetes/.manala/etc/profile.d/message.sh.tmpl
@@ -34,10 +34,6 @@ printf " \033[36m‣ k9s \033[35m{{ $k9s.version }}\033[0m\n"
 {{- if $stern.version }}
 printf " \033[36m‣ stern \033[35m{{ $stern.version }}\033[0m\n"
 {{- end }}
-{{- $kubePrompt := index .Vars.system "kube-prompt" }}
-{{- if $kubePrompt.version }}
-printf " \033[36m‣ kube-prompt \033[35m{{ $kubePrompt.version }}\033[0m\n"
-{{- end }}
 {{- $popeye := .Vars.system.popeye }}
 {{- if $popeye.version }}
 printf " \033[36m‣ popeye \033[35m{{ $popeye.version }}\033[0m\n"

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -36,8 +36,6 @@ system:
         version: 0.32.5
     stern:
         version: 1.30.0
-    kube-prompt:
-        version: 1.0.11
     popeye:
         version: 0.21.5
     knsk:


### PR DESCRIPTION
The project is abandoned, last version was in 2021 :)

See: https://github.com/c-bata/kube-prompt/releases