### PR TITLE
[Lazy] Use host TERM

### DIFF
--- a/lazy.ansible/.manala/docker/compose/term.yaml
+++ b/lazy.ansible/.manala/docker/compose/term.yaml
@@ -1,0 +1,9 @@
+services:
+
+    ##########
+    # System #
+    ##########
+
+    system:
+        environment:
+            TERM: ${TERM:-xterm}

--- a/lazy.ansible/.manala/docker/docker.mk
+++ b/lazy.ansible/.manala/docker/docker.mk
@@ -101,6 +101,9 @@ MANALA_DOCKER_COMPOSE_FILE += \
 # Debug
 MANALA_DOCKER_COMPOSE_ENV += $(if $(MANALA_DOCKER_DEBUG), BUILDKIT_PROGRESS=plain)
 
+# Term
+MANALA_DOCKER_COMPOSE_FILE += $(MANALA_DIR)/.manala/docker/compose/term.yaml
+
 # Usage:
 #   $(manala_docker_compose) [COMMAND] [ARGS...]
 

--- a/lazy.kubernetes/.manala/docker/compose/term.yaml
+++ b/lazy.kubernetes/.manala/docker/compose/term.yaml
@@ -1,0 +1,9 @@
+services:
+
+    ##########
+    # System #
+    ##########
+
+    system:
+        environment:
+            TERM: ${TERM:-xterm}

--- a/lazy.kubernetes/.manala/docker/docker.mk
+++ b/lazy.kubernetes/.manala/docker/docker.mk
@@ -101,6 +101,9 @@ MANALA_DOCKER_COMPOSE_FILE += \
 # Debug
 MANALA_DOCKER_COMPOSE_ENV += $(if $(MANALA_DOCKER_DEBUG), BUILDKIT_PROGRESS=plain)
 
+# Term
+MANALA_DOCKER_COMPOSE_FILE += $(MANALA_DIR)/.manala/docker/compose/term.yaml
+
 # Usage:
 #   $(manala_docker_compose) [COMMAND] [ARGS...]
 

--- a/lazy.symfony/.manala/docker/compose/term.yaml
+++ b/lazy.symfony/.manala/docker/compose/term.yaml
@@ -1,0 +1,9 @@
+services:
+
+    ##########
+    # System #
+    ##########
+
+    system:
+        environment:
+            TERM: ${TERM:-xterm}

--- a/lazy.symfony/.manala/docker/docker.mk
+++ b/lazy.symfony/.manala/docker/docker.mk
@@ -109,6 +109,9 @@ MANALA_DOCKER_COMPOSE_FILE += $(foreach SERVICE, $(MANALA_DOCKER_SERVICES), \
 # Debug
 MANALA_DOCKER_COMPOSE_ENV += $(if $(MANALA_DOCKER_DEBUG), BUILDKIT_PROGRESS=plain)
 
+# Term
+MANALA_DOCKER_COMPOSE_FILE += $(MANALA_DIR)/.manala/docker/compose/term.yaml
+
 # Usage:
 #   $(manala_docker_compose) [COMMAND] [ARGS...]
 


### PR DESCRIPTION
Pass host TERM environment variable to system container, to benefit - among other things - from more colors in cli when available.

Note that OpenSSH does exactly the same when connecting to an another host.

Note also the default `xterm` TERM we use; docker itself does the same: https://github.com/docker-archive/docker-ce/blob/7772923773ab88e8f7d20528a24f882014e0d8e4/components/engine/container/container.go#L736-L744