### PR TITLE
[Lazy] Stop trying to pull local builded images

### DIFF
--- a/lazy.ansible/.manala/docker/compose.yaml.tmpl
+++ b/lazy.ansible/.manala/docker/compose.yaml.tmpl
@@ -14,6 +14,7 @@ services:
             context: ..
             dockerfile: docker/Dockerfile
         image: {{ .Vars.project.name }}:{{ $now }}
+        pull_policy: never
         volumes:
             - ../..:${MANALA_DIR}
             {{- range $mount := .Vars.system.mount }}

--- a/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
+++ b/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
@@ -14,6 +14,7 @@ services:
             context: ..
             dockerfile: docker/Dockerfile
         image: {{ .Vars.project.name }}:{{ $now }}
+        pull_policy: never
         volumes:
             - ../..:${MANALA_DIR}
             {{- range $mount := .Vars.system.mount }}

--- a/lazy.symfony/.manala/docker/compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker/compose.yaml.tmpl
@@ -14,6 +14,7 @@ services:
             context: ..
             dockerfile: docker/Dockerfile
         image: {{ .Vars.project.name }}:{{ $now }}
+        pull_policy: never
         restart: always
         ports:
             - {{ .Vars.system.nginx.port }}:80


### PR DESCRIPTION
Tired of this message during the first build ?
```
! system Warning pull access denied for project, repository does not exist or may require 'docker login': denied: requested access to the resource is denied  
```

Well, docker compose has THE option: https://docs.docker.com/reference/compose-file/services/#pull_policy

 "What happen exactly ?" you may ask.
Well, by setting an `image` in the docker compose service with a variable date, we ensure the image will be re-built after each `manala up`. But even if the service has a `build` parameter, docker compose tries to pull the image on the docker registry, leading to the infamous error...

BUT that was BEFORE this marvellous pull request.