### PR TITLE
[Lazy] Enhanced zsh make completion

### DIFF
--- a/lazy.ansible/.manala/etc/zsh/.zshrc.tmpl
+++ b/lazy.ansible/.manala/etc/zsh/.zshrc.tmpl
@@ -119,5 +119,9 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
+# See: https://seankhliao.com/blog/12021-07-29-makefile-notes/#-zsh--completion
+zstyle ':completion:*:make:*:targets' call-command true
+zstyle ':completion:*:make:*' tag-order targets
+
 # Starship
 eval "$(starship init zsh)"

--- a/lazy.kubernetes/.manala/etc/zsh/.zshrc.tmpl
+++ b/lazy.kubernetes/.manala/etc/zsh/.zshrc.tmpl
@@ -143,5 +143,9 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
+# See: https://seankhliao.com/blog/12021-07-29-makefile-notes/#-zsh--completion
+zstyle ':completion:*:make:*:targets' call-command true
+zstyle ':completion:*:make:*' tag-order targets
+
 # Starship
 eval "$(starship init zsh)"

--- a/lazy.symfony/.manala/etc/zsh/.zshrc.tmpl
+++ b/lazy.symfony/.manala/etc/zsh/.zshrc.tmpl
@@ -118,5 +118,9 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
+# See: https://seankhliao.com/blog/12021-07-29-makefile-notes/#-zsh--completion
+zstyle ':completion:*:make:*:targets' call-command true
+zstyle ':completion:*:make:*' tag-order targets
+
 # Starship
 eval "$(starship init zsh)"


### PR DESCRIPTION
See: https://seankhliao.com/blog/12021-07-29-makefile-notes/#-zsh--completion

> zsh has built in support for extracting targets from Makefiles for autocompletion. Unfortunately, it can more or less only extract the statically defined targets. If you use patterns, wildcards, etc., you'll have to actually execute make to generate targets. Also, you'll likely want to skip the builtin make variables as autocomplete targets.