### PR TITLE
[All] Use github action cache v2

### DIFF
--- a/elao.app.docker/.manala/github/system/setup/action.yaml
+++ b/elao.app.docker/.manala/github/system/setup/action.yaml
@@ -56,8 +56,8 @@ runs:
       shell: bash
       run: |
         cat << EOF >> ${{ github.env }}
-        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }}
-        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }}
+        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
+        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
         ${{ inputs.docker_compose_profile != ''
           && format('MANALA_DOCKER_COMPOSE_PROFILE={0}', inputs.docker_compose_profile)
           || ''

--- a/lazy.ansible/.manala/github/system/setup/action.yaml
+++ b/lazy.ansible/.manala/github/system/setup/action.yaml
@@ -56,8 +56,8 @@ runs:
       shell: bash
       run: |
         cat << EOF >> ${{ github.env }}
-        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }}
-        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }}
+        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
+        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
         ${{ inputs.docker_compose_profile != ''
           && format('MANALA_DOCKER_COMPOSE_PROFILE={0}', inputs.docker_compose_profile)
           || ''

--- a/lazy.kubernetes/.manala/github/system/setup/action.yaml
+++ b/lazy.kubernetes/.manala/github/system/setup/action.yaml
@@ -56,8 +56,8 @@ runs:
       shell: bash
       run: |
         cat << EOF >> ${{ github.env }}
-        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }}
-        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }}
+        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
+        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
         ${{ inputs.docker_compose_profile != ''
           && format('MANALA_DOCKER_COMPOSE_PROFILE={0}', inputs.docker_compose_profile)
           || ''

--- a/lazy.symfony/.manala/github/system/setup/action.yaml
+++ b/lazy.symfony/.manala/github/system/setup/action.yaml
@@ -56,8 +56,8 @@ runs:
       shell: bash
       run: |
         cat << EOF >> ${{ github.env }}
-        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }}
-        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }}
+        MANALA_DOCKER_CACHE_FROM=type=gha,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
+        MANALA_DOCKER_CACHE_TO=type=gha,scope=type=gha,mode=max,scope=${{ inputs.docker_build_cache_scope }},url_v2=${ACTIONS_RESULTS_URL}
         ${{ inputs.docker_compose_profile != ''
           && format('MANALA_DOCKER_COMPOSE_PROFILE={0}', inputs.docker_compose_profile)
           || ''


### PR DESCRIPTION
As long as the docker compose version available on github action runners is not >=  2.33.1, github action cache version could not be detected with the help of `ACTIONS_CACHE_SERVICE_V2` environment variable.
So we trick it by forcing the usage of `url_v2` parameter.

See: https://github.com/moby/buildkit/issues/5896