### PR TITLE
[Elao - App - Docker] Fix ansible yaml result deprecation

### DIFF
--- a/elao.app.docker/.manala/docker/Dockerfile.tmpl
+++ b/elao.app.docker/.manala/docker/Dockerfile.tmpl
@@ -237,7 +237,7 @@ RUN \
 force_color = True\n\
 display_skipped_hosts = False\n\
 retry_files_enabled = False\n\
-stdout_callback = community.general.yaml\n\
+callback_result_format = yaml\n\
 inject_facts_as_vars = False\n\
 check_mode_markers = True\n\
 [ssh_connection]\n\


### PR DESCRIPTION
Fix
```
[DEPRECATION WARNING]: community.general.yaml has been deprecated. The plugin 
has been superseded by the the option `result_format=yaml` in callback plugin 
ansible.builtin.default from ansible-core 2.13 onwards. This feature will be 
removed from community.general in version 13.0.0. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```