### PR TITLE
[Lazy] Update to Debian Trixie

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -57,9 +57,6 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     docker: false
-    goss:
-        # @schema {"enum": [null, "0.4.9", "0.3.23"]}
-        version: ~
     apt:
         # @schema {"items": {"type": "string"}}
         packages: []

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -4,14 +4,13 @@
 # Base #
 ########
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="4.3.3"
 ARG DIRENV_VERSION="2.37.1"
 ARG JQ_VERSION="1.7.1"
@@ -42,6 +41,7 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     curl \
     git \
     gnupg \
+    gosu \
     less \
     libarchive-tools \
     make \
@@ -56,10 +56,6 @@ addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
 install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID}
 echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy
-# Gosu
-curl -sSLf "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/gosu
-chmod +x /usr/local/bin/gosu
 # Gomplate
 curl -sSLf "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
     --output /usr/local/bin/gomplate
@@ -140,17 +136,6 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     docker-ce-cli
 # Clean
 rm -rf /var/lib/apt/lists/*
-EOF
-
-{{ end -}}
-
-{{ $goss := .Vars.system.goss -}}
-{{ if $goss.version -}}
-# Goss
-RUN <<EOF
-curl -sSLf "https://github.com/goss-org/goss/releases/download/v{{ $goss.version }}/goss-linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/goss
-chmod +x /usr/local/bin/goss
 EOF
 
 {{ end -}}

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -15,10 +15,9 @@ system:
         - path: .env.3
           required: false
     docker: true
-    goss:
-        version: 0.4.9
     apt:
         packages:
+            - goss
             - nano
     git:
         config: |

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -1,4 +1,7 @@
 package:
+  # Base
+  gosu:
+    installed: true
   # System
   openssh-client:
     installed: true
@@ -33,7 +36,7 @@ file:
   /etc/os-release:
     exists: true
     contents:
-      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+      - PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
   # Git
   /etc/gitconfig:
     exists: true
@@ -47,10 +50,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "/\\d+\\.\\d+/"
   gomplate --version:
     exit-status: 0
     stdout:
@@ -75,11 +74,6 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
-  # Goss
-  goss --version:
-    exit-status: 0
-    stdout:
-      - goss version v{{ .Vars.system.goss.version }}
   # Env
   echo ${TEST}:
     exit-status: 0

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -57,9 +57,6 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     docker: false
-    goss:
-        # @schema {"enum": [null, "0.4.9", "0.3.23"]}
-        version: ~
     apt:
         # @schema {"items": {"type": "string"}}
         packages: []

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -4,14 +4,13 @@
 # Base #
 ########
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="4.3.3"
 ARG DIRENV_VERSION="2.37.1"
 ARG JQ_VERSION="1.7.1"
@@ -42,6 +41,7 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     curl \
     git \
     gnupg \
+    gosu \
     less \
     libarchive-tools \
     make \
@@ -56,10 +56,6 @@ addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
 install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID}
 echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy
-# Gosu
-curl -sSLf "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/gosu
-chmod +x /usr/local/bin/gosu
 # Gomplate
 curl -sSLf "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
     --output /usr/local/bin/gomplate
@@ -140,17 +136,6 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     docker-ce-cli
 # Clean
 rm -rf /var/lib/apt/lists/*
-EOF
-
-{{ end -}}
-
-{{ $goss := .Vars.system.goss -}}
-{{ if $goss.version -}}
-# Goss
-RUN <<EOF
-curl -sSLf "https://github.com/goss-org/goss/releases/download/v{{ $goss.version }}/goss-linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/goss
-chmod +x /usr/local/bin/goss
 EOF
 
 {{ end -}}

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -15,10 +15,9 @@ system:
         - path: .env.3
           required: false
     docker: true
-    goss:
-        version: 0.4.9
     apt:
         packages:
+            - goss
             - nano
     git:
         config: |

--- a/lazy.kubernetes/test/goss.yaml
+++ b/lazy.kubernetes/test/goss.yaml
@@ -1,4 +1,7 @@
 package:
+  # Base
+  gosu:
+    installed: true
   # Docker
   docker-ce-cli:
     installed: true
@@ -24,7 +27,7 @@ file:
   /etc/os-release:
     exists: true
     contents:
-      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+      - PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
   # Git
   /etc/gitconfig:
     exists: true
@@ -33,10 +36,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "/\\d+\\.\\d+/"
   gomplate --version:
     exit-status: 0
     stdout:
@@ -61,11 +60,6 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
-  # Goss
-  goss --version:
-    exit-status: 0
-    stdout:
-      - goss version v{{ .Vars.system.goss.version }}
   # Env
   echo ${TEST}:
     exit-status: 0

--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -58,9 +58,6 @@ system:
         # @schema {"type": ["null", "string"]}
         config: ~
     docker: false
-    goss:
-        # @schema {"enum": [null, "0.4.4", "0.3.23"]}
-        version: ~
     apt:
         # @schema {"items": {"type": "string"}}
         packages: []
@@ -69,7 +66,7 @@ system:
         config: ~
     nginx:
         # @option {"label": "Nginx version"}
-        # @schema {"enum": [1.24]}
+        # @schema {"enum": [1.28]}
         version: ~
         # @schema {"type": "integer", "exclusiveMinimum": 1024, "maximum": 65535}
         port: 8000

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -4,14 +4,13 @@
 # Base #
 ########
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ARG MANALA_USER_ID="1000"
 ARG MANALA_GROUP_ID="1000"
 
-ARG GOSU_VERSION="1.17"
 ARG GOMPLATE_VERSION="4.3.3"
 ARG DIRENV_VERSION="2.37.1"
 ARG JQ_VERSION="1.7.1"
@@ -42,6 +41,7 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     curl \
     git \
     gnupg \
+    gosu \
     less \
     libarchive-tools \
     make \
@@ -56,10 +56,6 @@ addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
 install --verbose --mode 0755 --group lazy --owner lazy --directory /run/user/${MANALA_USER_ID}
 echo "lazy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lazy
-# Gosu
-curl -sSLf "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/gosu
-chmod +x /usr/local/bin/gosu
 # Gomplate
 curl -sSLf "https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
     --output /usr/local/bin/gomplate
@@ -131,17 +127,6 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     docker-ce-cli
 # Clean
 rm -rf /var/lib/apt/lists/*
-EOF
-
-{{ end -}}
-
-{{ $goss := .Vars.system.goss -}}
-{{ if $goss.version -}}
-# Goss
-RUN <<EOF
-curl -sSLf "https://github.com/goss-org/goss/releases/download/v{{ $goss.version }}/goss-linux-{{ include "arch_map" (dict "amd64" "amd64" "arm64" "arm64") }}" \
-    --output /usr/local/bin/goss
-chmod +x /usr/local/bin/goss
 EOF
 
 {{ end -}}

--- a/lazy.symfony/test/.manala.yaml
+++ b/lazy.symfony/test/.manala.yaml
@@ -15,16 +15,15 @@ system:
         - path: .env.3
           required: false
     docker: true
-    goss:
-        version: 0.4.4
     apt:
         packages:
+            - goss
             - nano
     git:
         config: |
             # Git config
     nginx:
-        version: 1.24
+        version: 1.28
     php:
         version: 8.3
         extensions:

--- a/lazy.symfony/test/goss.yaml
+++ b/lazy.symfony/test/goss.yaml
@@ -1,4 +1,7 @@
 package:
+  # Base
+  gosu:
+    installed: true
   # System
   unzip:
     installed: true
@@ -32,7 +35,7 @@ file:
   /etc/os-release:
     exists: true
     contents:
-      - PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+      - PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
   # Git
   /etc/gitconfig:
     exists: true
@@ -41,10 +44,6 @@ file:
 
 command:
   # Base
-  gosu --version:
-    exit-status: 0
-    stdout:
-      - "/\\d+\\.\\d+/"
   gomplate --version:
     exit-status: 0
     stdout:
@@ -69,11 +68,6 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
-  # Goss
-  goss --version:
-    exit-status: 0
-    stdout:
-      - goss version v{{ .Vars.system.goss.version }}
   # Env
   echo ${TEST}:
     exit-status: 0


### PR DESCRIPTION
Notes:

- Switch to `gosu` debian package, now available in a decent version in debian repository
- Update `lazy.symfony` `nginx` component to version `1.28`, the minimum version available in nginx trixie packages repository
- Remove `goss` as component, must now be installed as an apt package
```yaml
system:
    # Before
    goss:
        version: 0.4.9
    # After
    apt:
        packages:
            - goss
```