### PR TITLE
[All] Add option to keep socat's log behaviour

### DIFF
--- a/elao.app.docker/.manala/docker/entrypoint.sh
+++ b/elao.app.docker/.manala/docker/entrypoint.sh
@@ -7,7 +7,7 @@ if [ -n "${SSH_AUTH_SOCK}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/ssh-auth-bridge.sock ;
-      socat \
+      socat -d0 \
         UNIX-LISTEN:/var/run/ssh-auth-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/ssh-auth.sock ; \
       sleep 1; \
@@ -20,7 +20,7 @@ if [ -n "${DOCKER_HOST}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/docker-bridge.sock ;
-      socat -t 600 \
+      socat -d0 -t 600 \
         UNIX-LISTEN:/var/run/docker-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/docker.sock ; \
       sleep 1; \

--- a/lazy.ansible/.manala/docker/entrypoint.sh
+++ b/lazy.ansible/.manala/docker/entrypoint.sh
@@ -7,7 +7,7 @@ if [ -n "${SSH_AUTH_SOCK}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/ssh-auth-bridge.sock ;
-      socat \
+      socat -d0 \
         UNIX-LISTEN:/var/run/ssh-auth-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/ssh-auth.sock ; \
       sleep 1; \
@@ -20,7 +20,7 @@ if [ -n "${DOCKER_HOST}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/docker-bridge.sock ;
-      socat -t 600 \
+      socat -d0 -t 600 \
         UNIX-LISTEN:/var/run/docker-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/docker.sock ; \
       sleep 1; \

--- a/lazy.kubernetes/.manala/docker/entrypoint.sh
+++ b/lazy.kubernetes/.manala/docker/entrypoint.sh
@@ -7,7 +7,7 @@ if [ -n "${SSH_AUTH_SOCK}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/ssh-auth-bridge.sock ;
-      socat \
+      socat -d0 \
         UNIX-LISTEN:/var/run/ssh-auth-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/ssh-auth.sock ; \
       sleep 1; \
@@ -20,7 +20,7 @@ if [ -n "${DOCKER_HOST}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/docker-bridge.sock ;
-      socat -t 600 \
+      socat -d0 -t 600 \
         UNIX-LISTEN:/var/run/docker-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/docker.sock ; \
       sleep 1; \

--- a/lazy.symfony/.manala/docker/entrypoint.sh
+++ b/lazy.symfony/.manala/docker/entrypoint.sh
@@ -7,7 +7,7 @@ if [ -n "${SSH_AUTH_SOCK}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/ssh-auth-bridge.sock ;
-      socat \
+      socat -d0 \
         UNIX-LISTEN:/var/run/ssh-auth-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/ssh-auth.sock ; \
       sleep 1; \
@@ -20,7 +20,7 @@ if [ -n "${DOCKER_HOST}" ]; then
   sh -c " \
     while true; do \
       rm -f /var/run/docker-bridge.sock ;
-      socat -t 600 \
+      socat -d0 -t 600 \
         UNIX-LISTEN:/var/run/docker-bridge.sock,fork,mode=777 \
         UNIX-CONNECT:/var/run/docker.sock ; \
       sleep 1; \


### PR DESCRIPTION
Warnings are output since 1.8.0, so we add option to revert back to only output errors and fatals