### PR TITLE
[Lazy] Tmpfs

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -53,6 +53,8 @@ system:
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []
+    # @schema {"items": {"type": "string"}}
+    tmpfs: []
     starship:
         # @schema {"type": ["null", "string"]}
         config: ~

--- a/lazy.ansible/.manala.yaml.tmpl
+++ b/lazy.ansible/.manala.yaml.tmpl
@@ -22,6 +22,9 @@ system:
     #     - .env
     #     - path: .env.local
     #       required: false
+    # tmpfs:
+    #     - /tmp
+    #     - /foo/bar:exec
     # apt:
     #     packages:
     #         - nano

--- a/lazy.ansible/.manala/docker/compose.yaml.tmpl
+++ b/lazy.ansible/.manala/docker/compose.yaml.tmpl
@@ -24,8 +24,12 @@ services:
             - ../../{{ $mount }}:${MANALA_DIR}/{{ $mount }}
               {{- end }}
             {{- end }}
+        {{- if .Vars.system.tmpfs }}
         tmpfs:
-            - /tmp
+            {{- range $fs := .Vars.system.tmpfs }}
+            - {{ $fs }}
+            {{- end }}
+        {{- end }}
         environment:
             MANALA_DIR: ${MANALA_DIR}
             MANALA_CACHE_DIR: ${MANALA_CACHE_DIR}

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -14,6 +14,9 @@ system:
           required: false
         - path: .env.3
           required: false
+    tmpfs:
+        - /tmpfs
+        - /tmpfs/exec:exec
     docker: true
     apt:
         packages:

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -31,6 +31,17 @@ user:
       - lazy
     shell: /bin/zsh
 
+mount:
+  # Tmpfs
+  /tmpfs:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, noexec, relatime]
+  /tmpfs/exec:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, relatime]
+
 file:
   # Base
   /etc/os-release:

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -53,6 +53,8 @@ system:
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []
+    # @schema {"items": {"type": "string"}}
+    tmpfs: []
     starship:
         # @schema {"type": ["null", "string"]}
         config: ~

--- a/lazy.kubernetes/.manala.yaml.tmpl
+++ b/lazy.kubernetes/.manala.yaml.tmpl
@@ -22,6 +22,9 @@ system:
     #     - .env
     #     - path: .env.local
     #       required: false
+    # tmpfs:
+    #     - /tmp
+    #     - /foo/bar:exec
     # apt:
     #     packages:
     #         - nano

--- a/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
+++ b/lazy.kubernetes/.manala/docker/compose.yaml.tmpl
@@ -24,8 +24,12 @@ services:
             - ../../{{ $mount }}:${MANALA_DIR}/{{ $mount }}
               {{- end }}
             {{- end }}
+        {{- if .Vars.system.tmpfs }}
         tmpfs:
-            - /tmp
+            {{- range $fs := .Vars.system.tmpfs }}
+            - {{ $fs }}
+            {{- end }}
+        {{- end }}
         environment:
             MANALA_DIR: ${MANALA_DIR}
             MANALA_CACHE_DIR: ${MANALA_CACHE_DIR}

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -14,6 +14,9 @@ system:
           required: false
         - path: .env.3
           required: false
+    tmpfs:
+        - /tmpfs
+        - /tmpfs/exec:exec
     docker: true
     apt:
         packages:

--- a/lazy.kubernetes/test/goss.yaml
+++ b/lazy.kubernetes/test/goss.yaml
@@ -22,6 +22,17 @@ user:
       - lazy
     shell: /bin/zsh
 
+mount:
+  # Tmpfs
+  /tmpfs:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, noexec, relatime]
+  /tmpfs/exec:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, relatime]
+
 file:
   # Base
   /etc/os-release:

--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -54,6 +54,8 @@ system:
     env_file: []
     # @schema {"items": {"type": "string"}}
     mount: []
+    # @schema {"items": {"type": "string"}}
+    tmpfs: []
     starship:
         # @schema {"type": ["null", "string"]}
         config: ~

--- a/lazy.symfony/.manala.yaml.tmpl
+++ b/lazy.symfony/.manala.yaml.tmpl
@@ -22,6 +22,9 @@ system:
     #     - .env
     #     - path: .env.local
     #       required: false
+    # tmpfs:
+    #     - /tmp
+    #     - /foo/bar:exec
     # apt:
     #     packages:
     #         - nano

--- a/lazy.symfony/.manala/docker/compose.yaml.tmpl
+++ b/lazy.symfony/.manala/docker/compose.yaml.tmpl
@@ -30,8 +30,12 @@ services:
             - ../../{{ $mount }}:${MANALA_DIR}/{{ $mount }}
               {{- end }}
             {{- end }}
+        {{- if .Vars.system.tmpfs }}
         tmpfs:
-            - /tmp
+            {{- range $fs := .Vars.system.tmpfs }}
+            - {{ $fs }}
+            {{- end }}
+        {{- end }}
         environment:
             MANALA_DIR: ${MANALA_DIR}
             MANALA_CACHE_DIR: ${MANALA_CACHE_DIR}

--- a/lazy.symfony/test/.manala.yaml
+++ b/lazy.symfony/test/.manala.yaml
@@ -14,6 +14,9 @@ system:
           required: false
         - path: .env.3
           required: false
+    tmpfs:
+        - /tmpfs
+        - /tmpfs/exec:exec
     docker: true
     apt:
         packages:

--- a/lazy.symfony/test/goss.yaml
+++ b/lazy.symfony/test/goss.yaml
@@ -30,6 +30,17 @@ user:
       - lazy
     shell: /bin/zsh
 
+mount:
+  # Tmpfs
+  /tmpfs:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, noexec, relatime]
+  /tmpfs/exec:
+    exists: true
+    filesystem: tmpfs
+    opts: [rw, nosuid, nodev, relatime]
+
 file:
   # Base
   /etc/os-release:


### PR DESCRIPTION
Rollback on https://github.com/manala/manala-recipes/pull/508, and more !

Having a static `/tmp` as a tmpfs, is not flexible enough :( What about having others ? What about options such as `exec`/`noexec` ?

This PR removes the  static `/tmp`tmpfs  and introduces a new `tmpfs` option, directly mapped on docker compose on (see: https://docs.docker.com/reference/compose-file/services/#tmpfs)
```
system:
    tmpfs:
        - /tmp
        - /foo/bar:exec
```
