### PR TITLE
[Lazy] Locale

### DIFF
--- a/lazy.ansible/.manala.yaml
+++ b/lazy.ansible/.manala.yaml
@@ -30,6 +30,7 @@ project:
 
 system:
     dir: ~
+    locale: C.UTF-8
     # @schema {
     #     "additionalProperties": {"type": ["string", "integer"]},
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}

--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -23,9 +23,6 @@ ARG FZF_VERSION="0.65.2"
 # It's also internally used for checking we're running inside a container.
 ENV container="docker"
 
-# Default locale
-ENV LANG="C.UTF-8"
-
 # Starship
 ENV STARSHIP_CONFIG=/etc/starship/starship.toml
 
@@ -51,6 +48,13 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     sudo \
     vim \
     zsh
+{{- if ne .Vars.system.locale "C.UTF-8" }}
+# Locale
+apt-get --quiet --yes --no-install-recommends --verbose-versions install \
+    locales
+sed -i "/^# *{{ .Vars.system.locale }}\b/s/^# *//" /etc/locale.gen
+dpkg-reconfigure locales
+{{- end }}
 # User
 addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
@@ -89,6 +93,9 @@ chmod +x /usr/local/bin/fzf
 # Clean
 rm -rf /var/lib/apt/lists/*
 EOF
+
+# Locale
+ENV LANG="{{ .Vars.system.locale }}"
 
 ##########
 # System #

--- a/lazy.ansible/test/.manala.yaml
+++ b/lazy.ansible/test/.manala.yaml
@@ -6,6 +6,7 @@ project:
     name: lazy-ansible-test
 
 system:
+    locale: en_US.UTF-8
     env:
         TEST: test
     env_file:

--- a/lazy.ansible/test/goss.yaml
+++ b/lazy.ansible/test/goss.yaml
@@ -74,6 +74,11 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
+  # Locale
+  locale -a:
+    exit-status: 0
+    stdout:
+      - en_US.utf8
   # Env
   echo ${TEST}:
     exit-status: 0

--- a/lazy.kubernetes/.manala.yaml
+++ b/lazy.kubernetes/.manala.yaml
@@ -30,6 +30,7 @@ project:
 
 system:
     dir: ~
+    locale: C.UTF-8
     # @schema {
     #     "additionalProperties": {"type": ["string", "integer"]},
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}

--- a/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
+++ b/lazy.kubernetes/.manala/docker/Dockerfile.tmpl
@@ -23,9 +23,6 @@ ARG FZF_VERSION="0.65.2"
 # It's also internally used for checking we're running inside a container.
 ENV container="docker"
 
-# Default locale
-ENV LANG="C.UTF-8"
-
 # Starship
 ENV STARSHIP_CONFIG=/etc/starship/starship.toml
 
@@ -51,6 +48,13 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     sudo \
     vim \
     zsh
+{{- if ne .Vars.system.locale "C.UTF-8" }}
+# Locale
+apt-get --quiet --yes --no-install-recommends --verbose-versions install \
+    locales
+sed -i "/^# *{{ .Vars.system.locale }}\b/s/^# *//" /etc/locale.gen
+dpkg-reconfigure locales
+{{- end }}
 # User
 addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
@@ -89,6 +93,9 @@ chmod +x /usr/local/bin/fzf
 # Clean
 rm -rf /var/lib/apt/lists/*
 EOF
+
+# Locale
+ENV LANG="{{ .Vars.system.locale }}"
 
 ##########
 # System #

--- a/lazy.kubernetes/test/.manala.yaml
+++ b/lazy.kubernetes/test/.manala.yaml
@@ -6,6 +6,7 @@ project:
     name: lazy-kubernetes-test
 
 system:
+    locale: en_US.UTF-8
     env:
         TEST: test
     env_file:

--- a/lazy.kubernetes/test/goss.yaml
+++ b/lazy.kubernetes/test/goss.yaml
@@ -60,6 +60,11 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
+  # Locale
+  locale -a:
+    exit-status: 0
+    stdout:
+      - en_US.utf8
   # Env
   echo ${TEST}:
     exit-status: 0

--- a/lazy.symfony/.manala.yaml
+++ b/lazy.symfony/.manala.yaml
@@ -31,6 +31,7 @@ project:
 
 system:
     dir: ~
+    locale: C.UTF-8
     # @schema {
     #     "additionalProperties": {"type": ["string", "integer"]},
     #     "propertyNames": {"pattern": "^[A-Z_]+$"}

--- a/lazy.symfony/.manala/docker/Dockerfile.tmpl
+++ b/lazy.symfony/.manala/docker/Dockerfile.tmpl
@@ -23,9 +23,6 @@ ARG FZF_VERSION="0.65.2"
 # It's also internally used for checking we're running inside a container.
 ENV container="docker"
 
-# Default locale
-ENV LANG="C.UTF-8"
-
 # Starship
 ENV STARSHIP_CONFIG=/etc/starship/starship.toml
 
@@ -51,6 +48,13 @@ apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     sudo \
     vim \
     zsh
+{{- if ne .Vars.system.locale "C.UTF-8" }}
+# Locale
+apt-get --quiet --yes --no-install-recommends --verbose-versions install \
+    locales
+sed -i "/^# *{{ .Vars.system.locale }}\b/s/^# *//" /etc/locale.gen
+dpkg-reconfigure locales
+{{- end }}
 # User
 addgroup --gid ${MANALA_GROUP_ID} lazy
 adduser --home /home/lazy --shell /bin/zsh --uid ${MANALA_USER_ID} --gecos lazy --ingroup lazy --disabled-password lazy
@@ -89,6 +93,9 @@ chmod +x /usr/local/bin/fzf
 # Clean
 rm -rf /var/lib/apt/lists/*
 EOF
+
+# Locale
+ENV LANG="{{ .Vars.system.locale }}"
 
 ##########
 # System #

--- a/lazy.symfony/test/.manala.yaml
+++ b/lazy.symfony/test/.manala.yaml
@@ -6,6 +6,7 @@ project:
     name: lazy-symfony-test
 
 system:
+    locale: en_US.UTF-8
     env:
         TEST: test
     env_file:

--- a/lazy.symfony/test/goss.yaml
+++ b/lazy.symfony/test/goss.yaml
@@ -68,6 +68,11 @@ command:
     exit-status: 0
     stdout:
       - "/\\d+\\.\\d+\\.\\d+/"
+  # Locale
+  locale -a:
+    exit-status: 0
+    stdout:
+      - en_US.utf8
   # Env
   echo ${TEST}:
     exit-status: 0


### PR DESCRIPTION
One can now set locale \o/

```yaml
system:
    locale: en_US.UTF-8
```

Note: `C.UTF-8` is still the default one