### PR TITLE
[Lazy - Ansible] Use ansible-lint lock extra

### DIFF
--- a/lazy.ansible/.manala/docker/Dockerfile.tmpl
+++ b/lazy.ansible/.manala/docker/Dockerfile.tmpl
@@ -172,7 +172,7 @@ apt-get --quiet update
 apt-get --quiet --yes --no-install-recommends --verbose-versions install \
     "${BUILD_PACKAGES[@]}"
 pipx install --pip-args="--no-cache-dir" \
-    ansible-lint=={{ $ansibleLint.version }}
+    ansible-lint[lock]=={{ $ansibleLint.version }}
 {{- if $ansibleLint.dependencies }}
 pipx inject --pip-args="--no-cache-dir" ansible-lint \
     {{- range $i, $dependency := $ansibleLint.dependencies }}


### PR DESCRIPTION
According to the documentation:

> If you want to install the exact versions of all dependencies that were used to test a specific version of ansible-lint, you can add lock extra. This will only work with Python 3.10 or newer. Do this only inside a virtual environment.

This should keep us away from some dependencies nightmares :)