### PR TITLE
feat(renovate): handeling GitHub actions .tmpl file extension

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
     "schedule:weekly"
   ],
   "ignorePaths": [],
+  "github-actions": {
+    "managerFilePatterns": [
+      "/(^|/)action\\.ya?ml\\.tmpl$/"
+    ]
+  },
   "packageRules": [
     {
       "matchManagers": ["custom.regex"],


### PR DESCRIPTION
Groups GitHub Actions detected in recipe .tmpl files (via the custom regex manager) under the existing recipes github actions group, so they're bundled together with actions from regular .yaml files instead of landing in the generic custom components group.